### PR TITLE
Add retinotopic/tonotopic network with cross-modal remapping

### DIFF
--- a/model/PoissonNeuron.py
+++ b/model/PoissonNeuron.py
@@ -26,6 +26,11 @@ class PoissonNeuron(Neuron):
         self.vv = []
         self.spikeRecord = []
 
+    def setRate(self, meanSpikesPerSecond):
+        self.expectedMeanSpikeRate = meanSpikesPerSecond
+        self.meanSpikeProbabilityPerMs = (self.expectedMeanSpikeRate / 10)
+        self.poissonLambda = self.meanSpikeProbabilityPerMs * self.tau
+
     def step(self):
         self.time += self.tau
         # Evaluate Poisson source

--- a/model/PoissonPopulation.py
+++ b/model/PoissonPopulation.py
@@ -28,3 +28,8 @@ class PoissonPopulation(Population):
         # Inbound connections will call registerInboundConnection() as they are created, either via this population or via another.
         # Note: We handle internal connections as just outbound from and inbound to the same population
 
+    def setRate(self, meanSpikesPerSecond):
+        self.meanSpikesPerSecond = meanSpikesPerSecond
+        for cell in self.cells:
+            cell.setRate(meanSpikesPerSecond)
+

--- a/model/Population.py
+++ b/model/Population.py
@@ -119,8 +119,15 @@ class Population():
         windowSize = window[1] - window[0]
         scaleFactor = stepsPerSecond / windowSize
         for cell in self.cells:
-            for spike in cell.spikeRecord:
-                if window[0] < spike < window[1]:
+            # spikeRecord is appended in non-decreasing time order, so we can
+            # walk backward from the most recent spike and stop as soon as we
+            # fall out of the window, instead of rescanning the cell's entire
+            # spike history (which otherwise makes every step's cost grow
+            # with total elapsed spikes across the whole run).
+            for spike in reversed(cell.spikeRecord):
+                if spike <= window[0]:
+                    break
+                if spike < window[1]:
                     rate += 1
         return rate * scaleFactor
 

--- a/network/DemoRetinotopicAVNetwork.py
+++ b/network/DemoRetinotopicAVNetwork.py
@@ -1,0 +1,140 @@
+import sys
+import os
+
+# Allow running this script directly (python3 network/DemoRetinotopicAVNetwork.py)
+# regardless of the current working directory - see TestRetinotopicAVNetwork.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from datetime import datetime
+from absl import flags
+import matplotlib
+matplotlib.use("Agg")  # write figures to disk without needing a display
+import matplotlib.pyplot as plt
+import numpy as np
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string("lesion_mode", "scotoma", "Which lesion scenario to run: 'scotoma' or 'full'.")
+flags.DEFINE_string("video_path", None, "Greyscale video file to use as visual input. If unset, a small synthetic clip is generated and saved alongside the figures.")
+flags.DEFINE_string("beep_path", None, "Beep score CSV (time_ms,frequency_hz,amplitude) to use as audio input. If unset, a small synthetic score is generated and saved alongside the figures.")
+flags.DEFINE_string("figures_directory", os.path.join(os.curdir, "figures"), "Directory to write input fixtures and output plots into.")
+FLAGS(sys.argv)
+
+from network.RetinotopicAVParams import buildDefaultParams
+from sensory.SyntheticFixtures import writeSyntheticGreyscaleVideo, writeSyntheticBeepScore
+from sensory.VideoFrameSource import VideoFrameSource
+from sensory.BeepAudioSource import BeepAudioSource
+from simulation.RetinotopicAVSimulation import RetinotopicAVSimulation
+
+'''
+Runs one RetinotopicAVSimulation scenario end to end and writes out:
+  - the video/beep input files actually used (synthetic ones are generated
+    here instead of a throwaway temp dir, so they can be inspected/replayed)
+  - weight_over_time.png: mean weight of the "remapping" synapses across all
+    four phases, with phase boundaries marked
+  - activity_traces.png: firing rate over time for a few representative
+    columns (the lesioned site, and either a spared neighbor or the
+    cross-modal audio pathway, depending on lesion mode)
+  - activity_snapshots.png: a 1x4 spatial map of visual-grid activity at the
+    end of each phase, showing the scotoma appear and then refill
+
+Usage: python3 network/DemoRetinotopicAVNetwork.py [--lesion_mode=scotoma|full]
+'''
+
+def phaseBoundariesMs(sim):
+    d = sim.params["phaseDurationMs"]
+    return [d, 2 * d, 3 * d]
+
+def selectExampleColumns(sim):
+    network = sim.network
+    examples = [("lesioned %s" % str(sim.lesionedColumns[0]), "pyramidals" + network.visualColumnNames[sim.lesionedColumns[0]])]
+    if sim.lesionMode == "scotoma":
+        examples.append(("spared neighbor %s" % str(sim.spareNeighborColumns[0]), "pyramidals" + network.visualColumnNames[sim.spareNeighborColumns[0]]))
+        farColumn = (0, 0)
+        examples.append(("driven corner %s" % str(farColumn), "pyramidals" + network.visualColumnNames[farColumn]))
+    else:
+        edgeColumn = (0, 0)
+        examples.append(("lesioned edge (cross-modal) %s" % str(edgeColumn), "pyramidals" + network.visualColumnNames[edgeColumn]))
+        examples.append(("audio band 0", "pyramidals" + network.audioColumnNames[0]))
+    return examples
+
+def plotWeightHistory(sim, outputDir):
+    times = [t for t, _ in sim.weightHistory]
+    weights = [w for _, w in sim.weightHistory]
+    plt.figure()
+    plt.plot(times, weights)
+    for boundary in phaseBoundariesMs(sim):
+        plt.axvline(boundary, color="grey", linestyle="--", linewidth=1)
+    plt.xlabel("Time (ms)")
+    plt.ylabel("Mean remapping-synapse weight")
+    plt.title("Remapping synapse weight over time (%s)" % sim.lesionMode)
+    path = os.path.join(outputDir, "weight_over_time.png")
+    plt.savefig(path)
+    plt.close()
+    return path
+
+def plotActivityTraces(sim, outputDir):
+    plt.figure()
+    for label, popName in selectExampleColumns(sim):
+        rateRecord = sim.network.populations[popName].rateRecord
+        times = [i * sim.tau for i in range(len(rateRecord))]
+        plt.plot(times, rateRecord, label=label)
+    for boundary in phaseBoundariesMs(sim):
+        plt.axvline(boundary, color="grey", linestyle="--", linewidth=1)
+    plt.xlabel("Time (ms)")
+    plt.ylabel("Firing rate (spikes/sec, trailing 50ms window)")
+    plt.title("Pyramidal activity traces (%s)" % sim.lesionMode)
+    plt.legend(fontsize="small")
+    path = os.path.join(outputDir, "activity_traces.png")
+    plt.savefig(path)
+    plt.close()
+    return path
+
+def plotActivitySnapshots(sim, outputDir):
+    names = list(sim.activitySnapshots.keys())
+    grids = list(sim.activitySnapshots.values())
+    vmax = max(grid.max() for grid in grids) if grids else 1.0
+    vmax = vmax if vmax > 0 else 1.0
+    fig, axes = plt.subplots(1, len(grids), figsize=(4 * len(grids), 4))
+    if len(grids) == 1:
+        axes = [axes]
+    im = None
+    for ax, name, grid in zip(axes, names, grids):
+        im = ax.pcolor(grid, vmin=0, vmax=vmax)
+        ax.set_title(name)
+        ax.invert_yaxis()
+    fig.colorbar(im, ax=axes, shrink=0.7)
+    fig.suptitle("Visual grid activity by phase (%s)" % sim.lesionMode)
+    path = os.path.join(outputDir, "activity_snapshots.png")
+    plt.savefig(path)
+    plt.close()
+    return path
+
+def main():
+    outputDir = os.path.join(FLAGS.figures_directory, "retinotopic_demo", datetime.utcnow().isoformat())
+    os.makedirs(outputDir, exist_ok=True)
+
+    videoPath = FLAGS.video_path or writeSyntheticGreyscaleVideo(os.path.join(outputDir, "input_video.mp4"))
+    beepPath = FLAGS.beep_path or writeSyntheticBeepScore(os.path.join(outputDir, "input_beep.csv"))
+    print("Visual input file: %s" % videoPath)
+    print("Audio input file:  %s" % beepPath)
+
+    params = buildDefaultParams()
+    video = VideoFrameSource(videoPath, gridRows=params["gridRows"], gridCols=params["gridCols"])
+    audio = BeepAudioSource(beepPath, numBands=params["numAudioColumns"])
+    sim = RetinotopicAVSimulation(params, video, audio, lesionMode=FLAGS.lesion_mode)
+
+    print("Running '%s' scenario (popCount=%d, phaseDurationMs=%d)..." %
+          (FLAGS.lesion_mode, params["popCount"], params["phaseDurationMs"]))
+    sim.run()
+
+    weightPath = plotWeightHistory(sim, outputDir)
+    tracePath = plotActivityTraces(sim, outputDir)
+    snapshotPath = plotActivitySnapshots(sim, outputDir)
+
+    print("Wrote:")
+    print("  " + weightPath)
+    print("  " + tracePath)
+    print("  " + snapshotPath)
+
+if __name__ == "__main__":
+    main()

--- a/network/DemoRetinotopicAVNetwork.py
+++ b/network/DemoRetinotopicAVNetwork.py
@@ -5,6 +5,7 @@ import os
 # regardless of the current working directory - see TestRetinotopicAVNetwork.py.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import random
 from datetime import datetime
 from absl import flags
 import matplotlib
@@ -26,16 +27,27 @@ from sensory.BeepAudioSource import BeepAudioSource
 from simulation.RetinotopicAVSimulation import RetinotopicAVSimulation
 
 '''
-Runs one RetinotopicAVSimulation scenario end to end and writes out:
+Runs a RetinotopicAVSimulation scenario twice - once with remapping enabled,
+once as a drift-only control with the same network/stimuli but serotonin and
+plasticity never switched on in phase3 - and writes out:
   - the video/beep input files actually used (synthetic ones are generated
     here instead of a throwaway temp dir, so they can be inspected/replayed)
   - weight_over_time.png: mean weight of the "remapping" synapses across all
-    four phases, with phase boundaries marked
+    four phases (remapping condition only - the control's weight never
+    changes by construction, since plasticity is never enabled), with phase
+    boundaries marked
   - activity_traces.png: firing rate over time for a few representative
-    columns (the lesioned site, and either a spared neighbor or the
-    cross-modal audio pathway, depending on lesion mode)
+    columns in the remapping condition (the lesioned site, and either a
+    spared neighbor or the cross-modal audio pathway, depending on lesion
+    mode)
   - activity_snapshots.png: a 1x4 spatial map of visual-grid activity at the
     end of each phase, showing the scotoma appear and then refill
+  - remapping_vs_control.png: the lesioned site's activity in both
+    conditions, overlaid. This network has enough recurrent excitation that
+    overall activity drifts upward over time even with no lesion or
+    plasticity change at all (visible within phase1 in activity_traces.png),
+    so this is the plot that actually isolates how much of the "recovery" is
+    caused by remapping specifically, versus that generic drift.
 
 Usage: python3 network/DemoRetinotopicAVNetwork.py [--lesion_mode=scotoma|full]
 '''
@@ -109,6 +121,35 @@ def plotActivitySnapshots(sim, outputDir):
     plt.close()
     return path
 
+def plotRemappingVsControl(experimentalSim, controlSim, outputDir):
+    lesionedCoord = experimentalSim.lesionedColumns[0]
+    lesionedPop = "pyramidals" + experimentalSim.network.visualColumnNames[lesionedCoord]
+
+    plt.figure()
+    for label, sim in [("remapping enabled", experimentalSim), ("control (no plasticity)", controlSim)]:
+        rateRecord = sim.network.populations[lesionedPop].rateRecord
+        times = [i * sim.tau for i in range(len(rateRecord))]
+        plt.plot(times, rateRecord, label=label)
+    for boundary in phaseBoundariesMs(experimentalSim):
+        plt.axvline(boundary, color="grey", linestyle="--", linewidth=1)
+    plt.xlabel("Time (ms)")
+    plt.ylabel("Firing rate (spikes/sec, trailing 50ms window)")
+    plt.title("Lesioned site %s: remapping vs. drift-only control (%s)" % (str(lesionedCoord), experimentalSim.lesionMode))
+    plt.legend(fontsize="small")
+    path = os.path.join(outputDir, "remapping_vs_control.png")
+    plt.savefig(path)
+    plt.close()
+    return path
+
+def buildAndRunSimulation(videoPath, beepPath, params, lesionMode, enableRemapping, seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    video = VideoFrameSource(videoPath, gridRows=params["gridRows"], gridCols=params["gridCols"])
+    audio = BeepAudioSource(beepPath, numBands=params["numAudioColumns"])
+    sim = RetinotopicAVSimulation(params, video, audio, lesionMode=lesionMode, enableRemapping=enableRemapping)
+    sim.run()
+    return sim
+
 def main():
     outputDir = os.path.join(FLAGS.figures_directory, "retinotopic_demo", datetime.utcnow().isoformat())
     os.makedirs(outputDir, exist_ok=True)
@@ -119,22 +160,25 @@ def main():
     print("Audio input file:  %s" % beepPath)
 
     params = buildDefaultParams()
-    video = VideoFrameSource(videoPath, gridRows=params["gridRows"], gridCols=params["gridCols"])
-    audio = BeepAudioSource(beepPath, numBands=params["numAudioColumns"])
-    sim = RetinotopicAVSimulation(params, video, audio, lesionMode=FLAGS.lesion_mode)
+    seed = 1234
 
-    print("Running '%s' scenario (popCount=%d, phaseDurationMs=%d)..." %
+    print("Running '%s' scenario with remapping enabled (popCount=%d, phaseDurationMs=%d)..." %
           (FLAGS.lesion_mode, params["popCount"], params["phaseDurationMs"]))
-    sim.run()
+    experimentalSim = buildAndRunSimulation(videoPath, beepPath, params, FLAGS.lesion_mode, enableRemapping=True, seed=seed)
 
-    weightPath = plotWeightHistory(sim, outputDir)
-    tracePath = plotActivityTraces(sim, outputDir)
-    snapshotPath = plotActivitySnapshots(sim, outputDir)
+    print("Running '%s' scenario as drift-only control (same seed, no plasticity)..." % FLAGS.lesion_mode)
+    controlSim = buildAndRunSimulation(videoPath, beepPath, params, FLAGS.lesion_mode, enableRemapping=False, seed=seed)
+
+    weightPath = plotWeightHistory(experimentalSim, outputDir)
+    tracePath = plotActivityTraces(experimentalSim, outputDir)
+    snapshotPath = plotActivitySnapshots(experimentalSim, outputDir)
+    comparisonPath = plotRemappingVsControl(experimentalSim, controlSim, outputDir)
 
     print("Wrote:")
     print("  " + weightPath)
     print("  " + tracePath)
     print("  " + snapshotPath)
+    print("  " + comparisonPath)
 
 if __name__ == "__main__":
     main()

--- a/network/RetinotopicAVNetwork.py
+++ b/network/RetinotopicAVNetwork.py
@@ -1,0 +1,240 @@
+import logging as log
+import numpy as np
+from model.Population import Population
+from model.PoissonPopulation import PoissonPopulation
+from network.Network import Network
+from model.AxonalSerotoninReceptorFactory import AxonalSerotoninDiffuseReceptorFactory
+from model.SomaticSerotoninReceptorFactory import SomaticSerotoninDiffuseReceptorFactory
+from random import random, gauss
+
+'''
+A retinotopic / tonotopic expansion of SerotoninAVNetwork.
+
+Instead of 3 visual + 2 audio columns wired (mostly) all-to-all, this network
+builds a (gridRows x gridCols) grid of visual columns - one per pixel of a
+downsampled greyscale video frame - and a 1D chain of numAudioColumns
+tonotopic audio columns - one per frequency band of a beep score.
+
+Each column (visual or audio) has the same internal structure as a column in
+SerotoninAVNetwork: an Input population driving a Pyramidal population, which
+in turn drives (and is driven by) Fast-Spiking and Low-Threshold populations.
+
+Connectivity between columns is local/topographic rather than all-to-all:
+  * Visual columns laterally connect (pyramidal -> pyramidal) to their
+    4-connected grid neighbors. This is the substrate for retinotopic
+    remapping: if a column's own input is silenced, its spared neighbors can
+    still drive it through these lateral connections.
+  * Audio columns laterally connect to their tonotopic chain neighbors
+    (band i <-> band i+1).
+  * Cross-modal connections are structured and sparse, mirroring how the
+    original network only cross-connected its edge visual columns (V1, V3) to
+    the two audio columns: here, the leftmost column of visual field connects
+    to the low half of the tonotopic chain, and the rightmost column connects
+    to the high half, one visual row per band.
+'''
+
+class RetinotopicAVNetwork(Network):
+    def __init__(self, tau, parentSimulation, params, name):
+        self.tau = tau
+        self.parentSimulation = parentSimulation
+        self.name = name
+        self.populations = {}
+        self.params = params
+
+        self.popCount = params["popCount"]
+        self.gridRows = params.get("gridRows", 10)
+        self.gridCols = params.get("gridCols", 10)
+        self.numAudioColumns = params.get("numAudioColumns", 20)
+
+        self.serotoninLevelV = params["serotoninLevelV"]
+        self.serotoninLevelA = params["serotoninLevelA"]
+        self.baselineRateV = params["baselineRateV"]
+        self.baselineRateA = params["baselineRateA"]
+        self.inputWeightV = params["inputWeightV"]
+        self.inputWeightA = params["inputWeightA"]
+        self.crossModalWeightVA = params["inputWeightVA"]
+        self.crossModalWeightAV = params["inputWeightAV"]
+        self.crossModalLikelihood = params["crossModalLikelihood"]
+        self.lateralVisualWeight = params["lateralVisualWeight"]
+        self.lateralVisualLikelihood = params["lateralVisualLikelihood"]
+        self.lateralAudioWeight = params["lateralAudioWeight"]
+        self.lateralAudioLikelihood = params["lateralAudioLikelihood"]
+        self.somaticSerotonin2AReceptorWeight = params["Somatic5HT2AWeight"]
+        self.somaticSerotonin1AReceptorWeight = params["Somatic5HT1AWeight"]
+        self.axonalSerotonin2AReceptorWeight = params["Axonal5HT2AWeight"]
+        self.axonalSerotonin1AReceptorWeight = params["Axonal5HT1AWeight"]
+        self.pyramidalSelfExcitationWeight = params["pyramidalSelfExcitationWeight"]
+
+        # Set up cell parameters (identical to SerotoninAVNetwork)
+        pyramidalParams = {"C": 100, "k": 3, "v_r": -60, "v_t": -50, "v_peak": 50,
+                            "a": 0.01, "b": 5, "c": -60, "d": 400, "type": "Pyramidal"}
+        fsParams = {"C": 20, "k": 1, "v_r": -55, "v_t": -40, "v_peak": 25,
+                    "a": 0.15, "b": 8, "c": -55, "d": 200, "type": "FS"}
+        ltsParams = {"C": 100, "k": 1, "v_r": -56, "v_t": -42, "v_peak": 40,
+                     "a": 0.03, "b": 8, "c": -50, "d": 200, "type": "LTS"}
+        inputVParams = {"spikeRate": self.baselineRateV, "type": "Poisson"}
+        inputAParams = {"spikeRate": self.baselineRateA, "type": "Poisson"}
+
+        # Diffuse receptor factories
+        factorySomatic5HT2A = SomaticSerotoninDiffuseReceptorFactory("5HT2A", lambda x: self.somaticSerotonin2AReceptorWeight, [])
+        factoryAxonal5HT2A = AxonalSerotoninDiffuseReceptorFactory("5HT2A", lambda x: self.axonalSerotonin2AReceptorWeight, [])
+
+        self.transmittersV = {"5HT2A": self.serotoninLevelV, "5HT1A": self.serotoninLevelV}
+        self.transmittersA = {"5HT2A": self.serotoninLevelA, "5HT1A": self.serotoninLevelA}
+
+        # Build visual columns (retinotopic grid)
+        self.visualColumnNames = {}
+        for r in range(self.gridRows):
+            for c in range(self.gridCols):
+                colName = self.visualColumnName(r, c)
+                self.visualColumnNames[(r, c)] = colName
+                self._buildColumn(colName, inputVParams, pyramidalParams, fsParams, ltsParams,
+                                   self.transmittersV, factorySomatic5HT2A)
+
+        # Build audio columns (tonotopic chain)
+        self.audioColumnNames = {}
+        for k in range(self.numAudioColumns):
+            colName = self.audioColumnName(k)
+            self.audioColumnNames[k] = colName
+            self._buildColumn(colName, inputAParams, pyramidalParams, fsParams, ltsParams,
+                               self.transmittersA, factorySomatic5HT2A)
+
+        # Within-column connectivity (feedforward + local E/I loop), same pattern for every column
+        for colName in list(self.visualColumnNames.values()) + list(self.audioColumnNames.values()):
+            self._wireColumnInternals(colName, factoryAxonal5HT2A)
+
+        # Lateral visual-visual connectivity: 4-connected grid neighbors, pyramidal -> pyramidal
+        for r in range(self.gridRows):
+            for c in range(self.gridCols):
+                sourceName = self.visualColumnNames[(r, c)]
+                for (nr, nc) in self.gridNeighbors(r, c):
+                    targetName = self.visualColumnNames[(nr, nc)]
+                    self.populations["pyramidals" + sourceName].addOutboundConnections(
+                        self.populations["pyramidals" + targetName],
+                        self.gaussWeightWithChanceFactory(self.lateralVisualWeight, self.lateralVisualLikelihood), [], [])
+
+        # Lateral audio-audio connectivity: tonotopic chain neighbors, pyramidal -> pyramidal
+        for k in range(self.numAudioColumns):
+            for neighborK in self._chainNeighbors(k, self.numAudioColumns):
+                sourceName = self.audioColumnNames[k]
+                targetName = self.audioColumnNames[neighborK]
+                self.populations["pyramidals" + sourceName].addOutboundConnections(
+                    self.populations["pyramidals" + targetName],
+                    self.gaussWeightWithChanceFactory(self.lateralAudioWeight, self.lateralAudioLikelihood), [], [])
+
+        # Cross-modal connectivity: left visual edge <-> low half of tonotopic chain,
+        # right visual edge <-> high half of tonotopic chain, one visual row per band.
+        self.leftEdgeBandForRow = self._edgeBandMapping(0, self.numAudioColumns // 2 - 1)
+        self.rightEdgeBandForRow = self._edgeBandMapping(self.numAudioColumns // 2, self.numAudioColumns - 1)
+        for r in range(self.gridRows):
+            self._wireCrossModalPair(self.visualColumnNames[(r, 0)], self.audioColumnNames[self.leftEdgeBandForRow[r]], factoryAxonal5HT2A)
+            self._wireCrossModalPair(self.visualColumnNames[(r, self.gridCols - 1)], self.audioColumnNames[self.rightEdgeBandForRow[r]], factoryAxonal5HT2A)
+
+    # ---- Naming helpers ----
+
+    def visualColumnName(self, r, c):
+        return "V%02d_%02d" % (r, c)
+
+    def audioColumnName(self, k):
+        return "A%02d" % k
+
+    # ---- Topology helpers ----
+
+    def gridNeighbors(self, r, c):
+        candidates = [(r - 1, c), (r + 1, c), (r, c - 1), (r, c + 1)]
+        return [(nr, nc) for (nr, nc) in candidates if 0 <= nr < self.gridRows and 0 <= nc < self.gridCols]
+
+    def _chainNeighbors(self, k, count):
+        candidates = [k - 1, k + 1]
+        return [n for n in candidates if 0 <= n < count]
+
+    def _edgeBandMapping(self, bandStart, bandEnd):
+        if self.gridRows == 1:
+            return np.array([bandStart])
+        return np.round(np.linspace(bandStart, bandEnd, self.gridRows)).astype(int)
+
+    # ---- Construction helpers ----
+
+    def _buildColumn(self, colName, inputParams, pyramidalParams, fsParams, ltsParams, transmitters, factorySomatic5HT2A):
+        self.populations["Input" + colName] = PoissonPopulation(self.tau, inputParams, self.popCount, [], {}, self, self.name)
+        self.populations["pyramidals" + colName] = Population(self.tau, pyramidalParams, self.popCount, [factorySomatic5HT2A], transmitters, self, colName + " Pyramidal Cells")
+        self.populations["fastSpikings" + colName] = Population(self.tau, fsParams, self.popCount, [factorySomatic5HT2A], transmitters, self, colName + " Fast Spiking Cells")
+        self.populations["lowThresholds" + colName] = Population(self.tau, ltsParams, self.popCount, [factorySomatic5HT2A], transmitters, self, colName + " Low Threshold Cells")
+
+    def _wireColumnInternals(self, colName, factoryAxonal5HT2A):
+        isVisual = colName.startswith("V")
+        inputWeight = self.inputWeightV if isVisual else self.inputWeightA
+        self.populations["Input" + colName].addOutboundConnections(
+            self.populations["pyramidals" + colName], self.gaussWeightWithChanceFactory(inputWeight, 1.0), [], [factoryAxonal5HT2A])
+        self.populations["pyramidals" + colName].addOutboundConnections(
+            self.populations["pyramidals" + colName], self.selfTargetingGaussWeightFactory(self.pyramidalSelfExcitationWeight), [], [])
+        self.populations["pyramidals" + colName].addOutboundConnections(
+            self.populations["fastSpikings" + colName], self.gaussWeightWithChanceFactory(self.params["PyramidalsToFSWeight"], 1.0), [], [])
+        self.populations["fastSpikings" + colName].addOutboundConnections(
+            self.populations["pyramidals" + colName], self.gaussWeightWithChanceFactory(self.params["FSToPyramidalsWeight"], 1.0), [], [])
+        self.populations["pyramidals" + colName].addOutboundConnections(
+            self.populations["lowThresholds" + colName], self.gaussWeightWithChanceFactory(self.params["PyramidalsToLTSWeight"], 1.0), [], [])
+
+    def _wireCrossModalPair(self, visualColName, audioColName, factoryAxonal5HT2A):
+        self.populations["Input" + visualColName].addOutboundConnections(
+            self.populations["pyramidals" + audioColName],
+            self.gaussWeightWithChanceFactory(self.crossModalWeightVA, self.crossModalLikelihood), [], [factoryAxonal5HT2A])
+        self.populations["Input" + audioColName].addOutboundConnections(
+            self.populations["pyramidals" + visualColName],
+            self.gaussWeightWithChanceFactory(self.crossModalWeightAV, self.crossModalLikelihood), [], [factoryAxonal5HT2A])
+
+    # ---- Weight function factories (same math as SerotoninAVNetwork) ----
+
+    def gaussWeightWithChanceFactory(self, inputWeight, chance):
+        def weightFunction(source, target):
+            if random() < chance:
+                return gauss(inputWeight / self.popCount, ((inputWeight / self.popCount) / 10))
+            else:
+                return None
+        return weightFunction
+
+    def selfTargetingGaussWeightFactory(self, inputWeight):
+        def weightFunction(source, target):
+            if source is target:
+                return gauss(inputWeight / self.popCount, ((inputWeight / self.popCount) / 10))
+            else:
+                return None
+        return weightFunction
+
+    # ---- Runtime drive / lesion / serotonin controls used by RetinotopicAVSimulation ----
+
+    def setVisualInputRate(self, r, c, rateHz):
+        self.populations["Input" + self.visualColumnNames[(r, c)]].setRate(rateHz)
+
+    def setVisualInputRates(self, rateGrid):
+        for r in range(self.gridRows):
+            for c in range(self.gridCols):
+                self.setVisualInputRate(r, c, rateGrid[r, c])
+
+    def setAudioInputRate(self, k, rateHz):
+        self.populations["Input" + self.audioColumnNames[k]].setRate(rateHz)
+
+    def setAudioInputRates(self, rateVector):
+        for k in range(self.numAudioColumns):
+            self.setAudioInputRate(k, rateVector[k])
+
+    def setSerotoninForColumns(self, columnNames, transmitters):
+        for colName in columnNames:
+            for popPrefix in ["pyramidals", "fastSpikings", "lowThresholds"]:
+                population = self.populations[popPrefix + colName]
+                population.setDiffuseTransmitters(transmitters)
+                for inboundAxon in population.inboundAxons:
+                    inboundAxon.updateDistalDiffuseTransmitters(transmitters)
+                for outboundAxon in population.outboundAxons:
+                    outboundAxon.updateProximalDiffuseTransmitters(transmitters)
+
+    def getAxonsBetween(self, sourcePopName, targetPopName):
+        sourcePop = self.populations[sourcePopName]
+        targetPop = self.populations[targetPopName]
+        return sourcePop.outboundAxonsByTargetPop.get(targetPop, [])
+
+    def step(self):
+        for popName, population in self.populations.items():
+            population.stepCells()
+        for popName, population in self.populations.items():
+            population.stepOutputs()

--- a/network/RetinotopicAVParams.py
+++ b/network/RetinotopicAVParams.py
@@ -8,6 +8,13 @@ def buildDefaultParams():
     params["frameDurationMs"] = 5
     params["phaseDurationMs"] = 20
 
+    # Visual input is flashed on for flashDurationMs, then blanked (dropped to
+    # baselineRateV) for blankDurationMs, repeating - instead of driving
+    # continuously from a looping clip with no rest between presentations.
+    # See RetinotopicAVSimulation's module docstring for why.
+    params["flashDurationMs"] = 5
+    params["blankDurationMs"] = 5
+
     params["serotoninLevelV"] = 10
     params["serotoninLevelA"] = 10
     params["remapSerotoninLevel"] = 30

--- a/network/RetinotopicAVParams.py
+++ b/network/RetinotopicAVParams.py
@@ -1,0 +1,47 @@
+def buildDefaultParams():
+    params = {}
+    params["popCount"] = 8
+    params["gridRows"] = 10
+    params["gridCols"] = 10
+    params["numAudioColumns"] = 20
+    params["tau"] = 0.1
+    params["frameDurationMs"] = 5
+    params["phaseDurationMs"] = 20
+
+    params["serotoninLevelV"] = 10
+    params["serotoninLevelA"] = 10
+    params["remapSerotoninLevel"] = 30
+    params["remapPlasticityCp"] = 90
+
+    # The pooled connection weights below (pyramidalSelfExcitationWeight etc.)
+    # are divided by popCount to get a per-synapse weight (see
+    # RetinotopicAVNetwork.gaussWeightWithChanceFactory). SerotoninAVNetwork's
+    # values were tuned for popCount=40; reusing them unscaled at a much
+    # smaller popCount makes each synapse disproportionately strong and drives
+    # the network into pathological, near-saturated firing. popCount/40 alone
+    # (0.2 here) overcorrects and leaves the network too quiet to fire once
+    # lesioned columns lose their own input, so this uses an empirically
+    # tuned factor that keeps activity in a healthy middle ground.
+    weightScale = 0.4
+
+    params["baselineRateV"] = 5
+    params["baselineRateA"] = 5
+    params["inputWeightV"] = 1500 * weightScale
+    params["inputWeightA"] = 1500 * weightScale
+    params["inputWeightVA"] = 800 * weightScale
+    params["inputWeightAV"] = 800 * weightScale
+    params["crossModalLikelihood"] = 0.3
+    params["lateralVisualWeight"] = 1500 * weightScale
+    params["lateralVisualLikelihood"] = 0.3
+    params["lateralAudioWeight"] = 1500 * weightScale
+    params["lateralAudioLikelihood"] = 0.3
+
+    params["Somatic5HT2AWeight"] = 20
+    params["Somatic5HT1AWeight"] = -5
+    params["Axonal5HT2AWeight"] = 0.2
+    params["Axonal5HT1AWeight"] = -0.2
+    params["pyramidalSelfExcitationWeight"] = 15000 * weightScale
+    params["PyramidalsToFSWeight"] = 50000 * weightScale
+    params["FSToPyramidalsWeight"] = -30000 * weightScale
+    params["PyramidalsToLTSWeight"] = 80000 * weightScale
+    return params

--- a/network/TestRetinotopicAVNetwork.py
+++ b/network/TestRetinotopicAVNetwork.py
@@ -1,0 +1,148 @@
+import sys
+import random
+import tempfile
+import os
+
+# Allow running this script directly (python3 network/TestRetinotopicAVNetwork.py)
+# regardless of the current working directory, since Python only puts the
+# script's own directory on sys.path, not the repo root the other packages
+# (sensory, simulation, ...) live under.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+from absl import flags
+
+FLAGS = flags.FLAGS
+FLAGS(sys.argv)
+
+from sensory.SyntheticFixtures import writeSyntheticGreyscaleVideo, writeSyntheticBeepScore
+from sensory.VideoFrameSource import VideoFrameSource
+from sensory.BeepAudioSource import BeepAudioSource
+from simulation.RetinotopicAVSimulation import RetinotopicAVSimulation
+
+'''
+Self-verifying test for RetinotopicAVNetwork / RetinotopicAVSimulation.
+
+Mirrors the phase progression demonstrated by TestTwoColumnNetworkManyTimes /
+TwoColumnSimulation (full input -> sensory loss -> serotonin rise with
+plasticity -> remapped, stable state), but on the 100-column retinotopic /
+20-column tonotopic network, driven by a real (synthetic) greyscale video and
+beep score. It runs both required scenarios - a partial scotoma and a
+full-field visual loss, with audio left active throughout both - and asserts
+that the relevant "remapping" synapses actually potentiated.
+
+This is a runnable script rather than a pytest suite, consistent with the
+rest of this repository's Test*.py files. It exits with status 0 on success
+and 1 if any assertion fails.
+'''
+
+random.seed(1234)
+np.random.seed(1234)
+
+def buildParams():
+    params = {}
+    params["popCount"] = 8
+    params["gridRows"] = 10
+    params["gridCols"] = 10
+    params["numAudioColumns"] = 20
+    params["tau"] = 0.1
+    params["frameDurationMs"] = 5
+    params["phaseDurationMs"] = 20
+
+    params["serotoninLevelV"] = 10
+    params["serotoninLevelA"] = 10
+    params["remapSerotoninLevel"] = 30
+    params["remapPlasticityCp"] = 90
+
+    # The pooled connection weights below (pyramidalSelfExcitationWeight etc.)
+    # are divided by popCount to get a per-synapse weight (see
+    # RetinotopicAVNetwork.gaussWeightWithChanceFactory). SerotoninAVNetwork's
+    # values were tuned for popCount=40; reusing them unscaled at a much
+    # smaller popCount makes each synapse disproportionately strong and drives
+    # the network into pathological, near-saturated firing. popCount/40 alone
+    # (0.2 here) overcorrects and leaves the network too quiet to fire once
+    # lesioned columns lose their own input, so this uses an empirically
+    # tuned factor that keeps activity in a healthy middle ground.
+    weightScale = 0.4
+
+    params["baselineRateV"] = 5
+    params["baselineRateA"] = 5
+    params["inputWeightV"] = 1500 * weightScale
+    params["inputWeightA"] = 1500 * weightScale
+    params["inputWeightVA"] = 800 * weightScale
+    params["inputWeightAV"] = 800 * weightScale
+    params["crossModalLikelihood"] = 0.3
+    params["lateralVisualWeight"] = 1500 * weightScale
+    params["lateralVisualLikelihood"] = 0.3
+    params["lateralAudioWeight"] = 1500 * weightScale
+    params["lateralAudioLikelihood"] = 0.3
+
+    params["Somatic5HT2AWeight"] = 20
+    params["Somatic5HT1AWeight"] = -5
+    params["Axonal5HT2AWeight"] = 0.2
+    params["Axonal5HT1AWeight"] = -0.2
+    params["pyramidalSelfExcitationWeight"] = 15000 * weightScale
+    params["PyramidalsToFSWeight"] = 50000 * weightScale
+    params["FSToPyramidalsWeight"] = -30000 * weightScale
+    params["PyramidalsToLTSWeight"] = 80000 * weightScale
+    return params
+
+def runScenario(lesionMode, videoPath, beepPath, params):
+    video = VideoFrameSource(videoPath, gridRows=params["gridRows"], gridCols=params["gridCols"])
+    audio = BeepAudioSource(beepPath, numBands=params["numAudioColumns"])
+    sim = RetinotopicAVSimulation(params, video, audio, lesionMode=lesionMode)
+    sim.run()
+    return sim
+
+def checkNetworkShape(sim, failures):
+    if len(sim.network.visualColumnNames) != 100:
+        failures.append("Expected 100 visual columns (10x10), got %d" % len(sim.network.visualColumnNames))
+    if len(sim.network.audioColumnNames) != 20:
+        failures.append("Expected 20 tonotopic audio columns, got %d" % len(sim.network.audioColumnNames))
+
+def checkRemapping(lesionMode, sim, failures):
+    if len(sim.remappingAxons) == 0:
+        failures.append("[%s] No remapping axons were found to potentiate" % lesionMode)
+        return
+
+    priorMean = float(np.mean(sim.weightsPrior))
+    postMean = float(np.mean(sim.weightsPost))
+    increasedCount = sum(1 for prior, post in zip(sim.weightsPrior, sim.weightsPost) if post > prior)
+    fraction = increasedCount / len(sim.remappingAxons)
+
+    print("[%s] remapping synapses: %d, mean weight prior=%.4f post=%.4f, fraction increased=%.2f" %
+          (lesionMode, len(sim.remappingAxons), priorMean, postMean, fraction))
+
+    # LTD (a small constant decay) fires on every presynaptic spike, while LTP
+    # (the bigger, timing-dependent term) only rewards synapses whose spikes
+    # closely preceded a postsynaptic spike. So remapping shows up as a net
+    # rise in mean weight, carried by a subset of well-timed synapses - not as
+    # a majority of individual synapses increasing.
+    if postMean <= priorMean * 1.001:
+        failures.append("[%s] Mean remapping weight did not increase (prior=%.4f, post=%.4f)" % (lesionMode, priorMean, postMean))
+    if fraction <= 0:
+        failures.append("[%s] No individual remapping synapse potentiated" % lesionMode)
+
+def main():
+    failures = []
+    with tempfile.TemporaryDirectory() as tmpDir:
+        videoPath = writeSyntheticGreyscaleVideo(os.path.join(tmpDir, "test_video.mp4"))
+        beepPath = writeSyntheticBeepScore(os.path.join(tmpDir, "test_beep.csv"))
+        params = buildParams()
+
+        for lesionMode in ("scotoma", "full"):
+            print("Running %s scenario..." % lesionMode)
+            sim = runScenario(lesionMode, videoPath, beepPath, params)
+            checkNetworkShape(sim, failures)
+            checkRemapping(lesionMode, sim, failures)
+
+    if failures:
+        print("FAILED:")
+        for failure in failures:
+            print("  - " + failure)
+        sys.exit(1)
+    else:
+        print("PASSED: retinotopic/tonotopic remapping occurred in both scenarios.")
+
+if __name__ == "__main__":
+    main()

--- a/network/TestRetinotopicAVNetwork.py
+++ b/network/TestRetinotopicAVNetwork.py
@@ -19,6 +19,7 @@ from sensory.SyntheticFixtures import writeSyntheticGreyscaleVideo, writeSynthet
 from sensory.VideoFrameSource import VideoFrameSource
 from sensory.BeepAudioSource import BeepAudioSource
 from simulation.RetinotopicAVSimulation import RetinotopicAVSimulation
+from network.RetinotopicAVParams import buildDefaultParams
 
 '''
 Self-verifying test for RetinotopicAVNetwork / RetinotopicAVSimulation.
@@ -39,53 +40,7 @@ and 1 if any assertion fails.
 random.seed(1234)
 np.random.seed(1234)
 
-def buildParams():
-    params = {}
-    params["popCount"] = 8
-    params["gridRows"] = 10
-    params["gridCols"] = 10
-    params["numAudioColumns"] = 20
-    params["tau"] = 0.1
-    params["frameDurationMs"] = 5
-    params["phaseDurationMs"] = 20
-
-    params["serotoninLevelV"] = 10
-    params["serotoninLevelA"] = 10
-    params["remapSerotoninLevel"] = 30
-    params["remapPlasticityCp"] = 90
-
-    # The pooled connection weights below (pyramidalSelfExcitationWeight etc.)
-    # are divided by popCount to get a per-synapse weight (see
-    # RetinotopicAVNetwork.gaussWeightWithChanceFactory). SerotoninAVNetwork's
-    # values were tuned for popCount=40; reusing them unscaled at a much
-    # smaller popCount makes each synapse disproportionately strong and drives
-    # the network into pathological, near-saturated firing. popCount/40 alone
-    # (0.2 here) overcorrects and leaves the network too quiet to fire once
-    # lesioned columns lose their own input, so this uses an empirically
-    # tuned factor that keeps activity in a healthy middle ground.
-    weightScale = 0.4
-
-    params["baselineRateV"] = 5
-    params["baselineRateA"] = 5
-    params["inputWeightV"] = 1500 * weightScale
-    params["inputWeightA"] = 1500 * weightScale
-    params["inputWeightVA"] = 800 * weightScale
-    params["inputWeightAV"] = 800 * weightScale
-    params["crossModalLikelihood"] = 0.3
-    params["lateralVisualWeight"] = 1500 * weightScale
-    params["lateralVisualLikelihood"] = 0.3
-    params["lateralAudioWeight"] = 1500 * weightScale
-    params["lateralAudioLikelihood"] = 0.3
-
-    params["Somatic5HT2AWeight"] = 20
-    params["Somatic5HT1AWeight"] = -5
-    params["Axonal5HT2AWeight"] = 0.2
-    params["Axonal5HT1AWeight"] = -0.2
-    params["pyramidalSelfExcitationWeight"] = 15000 * weightScale
-    params["PyramidalsToFSWeight"] = 50000 * weightScale
-    params["FSToPyramidalsWeight"] = -30000 * weightScale
-    params["PyramidalsToLTSWeight"] = 80000 * weightScale
-    return params
+buildParams = buildDefaultParams
 
 def runScenario(lesionMode, videoPath, beepPath, params):
     video = VideoFrameSource(videoPath, gridRows=params["gridRows"], gridCols=params["gridCols"])

--- a/network/TestRetinotopicAVNetwork.py
+++ b/network/TestRetinotopicAVNetwork.py
@@ -29,23 +29,35 @@ TwoColumnSimulation (full input -> sensory loss -> serotonin rise with
 plasticity -> remapped, stable state), but on the 100-column retinotopic /
 20-column tonotopic network, driven by a real (synthetic) greyscale video and
 beep score. It runs both required scenarios - a partial scotoma and a
-full-field visual loss, with audio left active throughout both - and asserts
-that the relevant "remapping" synapses actually potentiated.
+full-field visual loss, with audio left active throughout both.
+
+For each scenario it runs two conditions from the same random seed (so the
+network topology and initial state are identical): the real remapping
+condition, and a control where phase3/phase4 still run (same duration, same
+muting) but serotonin never rises and plasticity never switches on. This
+network has enough recurrent excitation that overall activity drifts upward
+over time on its own (visible even within phase1, before any lesion or
+plasticity change) - so the pass criteria below don't just check that the
+deprived column's activity went up, they check that (a) the remapping
+synapses' weight only moves in the real condition, and (b) the real
+condition's recovery specifically outstrips the control's, isolating the
+effect of remapping from generic drift.
 
 This is a runnable script rather than a pytest suite, consistent with the
 rest of this repository's Test*.py files. It exits with status 0 on success
 and 1 if any assertion fails.
 '''
 
-random.seed(1234)
-np.random.seed(1234)
+SEED = 1234
 
 buildParams = buildDefaultParams
 
-def runScenario(lesionMode, videoPath, beepPath, params):
+def runScenario(lesionMode, videoPath, beepPath, params, enableRemapping):
+    random.seed(SEED)
+    np.random.seed(SEED)
     video = VideoFrameSource(videoPath, gridRows=params["gridRows"], gridCols=params["gridCols"])
     audio = BeepAudioSource(beepPath, numBands=params["numAudioColumns"])
-    sim = RetinotopicAVSimulation(params, video, audio, lesionMode=lesionMode)
+    sim = RetinotopicAVSimulation(params, video, audio, lesionMode=lesionMode, enableRemapping=enableRemapping)
     sim.run()
     return sim
 
@@ -78,6 +90,30 @@ def checkRemapping(lesionMode, sim, failures):
     if fraction <= 0:
         failures.append("[%s] No individual remapping synapse potentiated" % lesionMode)
 
+def checkControlHasNoWeightChange(lesionMode, controlSim, failures):
+    # Without ever setting plasticity=True, boutonSpike()/postSynapticSpikeFeedback()
+    # can't touch weight at all - this should hold exactly, and guards against
+    # a regression that enables plasticity unconditionally somewhere.
+    if controlSim.weightsPrior != controlSim.weightsPost:
+        failures.append("[%s control] Remapping weight changed even though plasticity was never enabled" % lesionMode)
+
+def checkRemappingOutstripsDrift(lesionMode, experimentalSim, controlSim, failures):
+    # The real causal claim: with the same network, same stimuli, and the
+    # same generic activity drift in both conditions, the lesioned site
+    # should recover further with remapping enabled than without it.
+    lesionedCoord = experimentalSim.lesionedColumns[0]
+    experimentalActivity = experimentalSim.activitySnapshots["4_remapped"][lesionedCoord]
+    controlActivity = controlSim.activitySnapshots["4_remapped"][lesionedCoord]
+
+    print("[%s] lesioned-site phase4 activity: remapping=%.4f control (drift only)=%.4f" %
+          (lesionMode, experimentalActivity, controlActivity))
+
+    if experimentalActivity <= controlActivity:
+        failures.append(
+            "[%s] Remapping condition's recovered activity (%.4f) did not exceed the no-plasticity control's (%.4f) - "
+            "the apparent recovery may just be generic network drift, not remapping" %
+            (lesionMode, experimentalActivity, controlActivity))
+
 def main():
     failures = []
     with tempfile.TemporaryDirectory() as tmpDir:
@@ -86,10 +122,16 @@ def main():
         params = buildParams()
 
         for lesionMode in ("scotoma", "full"):
-            print("Running %s scenario..." % lesionMode)
-            sim = runScenario(lesionMode, videoPath, beepPath, params)
-            checkNetworkShape(sim, failures)
-            checkRemapping(lesionMode, sim, failures)
+            print("Running %s scenario (remapping)..." % lesionMode)
+            experimentalSim = runScenario(lesionMode, videoPath, beepPath, params, enableRemapping=True)
+            checkNetworkShape(experimentalSim, failures)
+            checkRemapping(lesionMode, experimentalSim, failures)
+
+            print("Running %s scenario (control, no plasticity)..." % lesionMode)
+            controlSim = runScenario(lesionMode, videoPath, beepPath, params, enableRemapping=False)
+            checkControlHasNoWeightChange(lesionMode, controlSim, failures)
+
+            checkRemappingOutstripsDrift(lesionMode, experimentalSim, controlSim, failures)
 
     if failures:
         print("FAILED:")
@@ -97,7 +139,7 @@ def main():
             print("  - " + failure)
         sys.exit(1)
     else:
-        print("PASSED: retinotopic/tonotopic remapping occurred in both scenarios.")
+        print("PASSED: remapping-specific recovery (beyond generic drift) occurred in both scenarios.")
 
 if __name__ == "__main__":
     main()

--- a/rate/ARTClassifier.py
+++ b/rate/ARTClassifier.py
@@ -1,0 +1,161 @@
+import numpy as np
+
+'''
+Fuzzy ART / ARTMAP-lite classifier for the retinotopic grand-plan secondary
+cortical area.
+
+Purpose in this project
+-----------------------
+The secondary area reads the V1 activity pattern and performs a TRIVIAL one-hot
+classification (person vs horse) with a REJECT option. The point is not image
+recognition; it is to provide a categorical readout that distinguishes:
+  * veridical perception : V1 pattern matches a learned category -> classify;
+  * blank / lost input    : V1 pattern too weak/unstructured -> reject;
+  * hallucination         : V1 confidently classifies despite no veridical
+                            bottom-up drive (e.g. top-down- or remapping-driven);
+  * recovery              : after cross-modal remapping, V1 re-classifies as the
+                            correct category.
+It also supplies content-specific top-down feedback: the winning category's
+template projected back onto V1 (the descending stream of the Sulfaro mixture).
+
+Why fuzzy ART
+-------------
+ART is the canonical neural architecture with a built-in reject/novelty test:
+the vigilance criterion. Fuzzy ART (Carpenter, Grossberg & Rosen 1991) extends
+it to analog inputs in [0,1] via the fuzzy AND (elementwise min) and complement
+coding. We use the standard equations:
+
+  complement coding : I = [x, 1 - x]                       (|I| = dim, constant)
+  choice (activation): T_j = |I ^ w_j| / (alpha + |w_j|)   (^ = elementwise min)
+  match             : rho_j = |I ^ w_j| / |I|
+  resonance         : winner J = argmax_j T_j; accept iff rho_J >= vigilance
+  fast-commit/slow-recode learning: w_J <- beta (I ^ w_J) + (1 - beta) w_J
+
+Supervised labels (ARTMAP-lite): each committed category carries a class label.
+During training, if the resonant category's label disagrees with the target
+label, MATCH TRACKING raises the effective vigilance just past the current match
+and re-searches, forcing a distinct category for the conflicting class -- the
+mechanism ARTMAP uses to guarantee the map is consistent with the labels.
+
+This is the discrete ART algorithm (exact choice/match/vigilance/search), used
+as a functional module that the rate network queries each step; it is not itself
+a population of rate neurons. That keeps the reject/vigilance semantics -- the
+scientific payload -- exact, rather than approximating them with lateral
+inhibition. The rate network supplies the input pattern (pooled V1 rates) and
+consumes the outputs (winner one-hot, reject flag, match, top-down template).
+'''
+
+REJECT = -1
+
+
+class FuzzyART:
+    def __init__(self, dim, vigilance=0.75, alpha=0.01, beta=1.0, activity_floor=0.05):
+        self.dim = int(dim)
+        self.vigilance = float(vigilance)
+        self.alpha = float(alpha)          # choice tie-breaker toward smaller categories
+        self.beta = float(beta)            # learning rate (1.0 = fast commit)
+        # Activity gate: an input whose mean drive is below this floor is
+        # rejected outright, before ART. Complement coding makes fuzzy ART match
+        # sparse/blank inputs against the complement half of every template, so
+        # vigilance alone does not reliably reject a near-silent input; the gate
+        # gives the semantics we need ("deprived / near-silent V1 -> no percept
+        # -> reject"), and is non-fragile (monotone in activity). Set to None to
+        # disable.
+        self.activity_floor = None if activity_floor is None else float(activity_floor)
+        self.weights = []                  # committed templates, each length 2*dim
+        self.labels = []                   # class label per committed category
+
+    # ---- coding ----
+
+    def _clip01(self, x):
+        x = np.asarray(x, dtype=float).ravel()
+        if x.shape[0] != self.dim:
+            raise ValueError("feature length %d != dim %d" % (x.shape[0], self.dim))
+        return np.clip(x, 0.0, 1.0)
+
+    def _complement(self, x01):
+        return np.concatenate([x01, 1.0 - x01])
+
+    # ---- ART primitives ----
+
+    def _choices(self, I):
+        # T_j = |I ^ w_j| / (alpha + |w_j|)
+        return np.array([np.sum(np.minimum(I, w)) / (self.alpha + np.sum(w))
+                         for w in self.weights])
+
+    def _match(self, I, w):
+        # rho_j = |I ^ w_j| / |I|   (|I| = dim under complement coding)
+        return np.sum(np.minimum(I, w)) / self.dim
+
+    # ---- inference ----
+
+    def classify(self, x, return_detail=False):
+        """Classify a feature vector without learning.
+
+        Returns the class label of the resonant category, or REJECT (-1) if no
+        committed category passes vigilance. With return_detail, also returns
+        (category_index, match) for the best resonant (or best overall) node.
+        """
+        x01 = self._clip01(x)
+        if self.activity_floor is not None and float(np.mean(x01)) < self.activity_floor:
+            # Near-silent input: no percept to classify.
+            return (REJECT, (None, 0.0)) if return_detail else REJECT
+        I = self._complement(x01)
+        if not self.weights:
+            return (REJECT, (None, 0.0)) if return_detail else REJECT
+        T = self._choices(I)
+        order = np.argsort(T)[::-1]
+        best_match = 0.0
+        for j in order:
+            m = self._match(I, self.weights[j])
+            best_match = max(best_match, m)
+            if m >= self.vigilance:
+                lbl = self.labels[j]
+                return (lbl, (j, m)) if return_detail else lbl
+        return (REJECT, (None, best_match)) if return_detail else REJECT
+
+    def category_template(self, category_index):
+        """Decomplemented template x-part (length dim) of a committed category,
+        i.e. the pattern that category feeds back top-down. For fuzzy ART the
+        x-part of w is the elementwise-min lower envelope of that category's
+        exemplars."""
+        return self.weights[category_index][:self.dim].copy()
+
+    # ---- learning ----
+
+    def train_one(self, x, label):
+        """Present one labeled example; run ART search with match tracking and
+        either learn into a resonant same-label category or commit a new one.
+        Returns the committed/updated category index."""
+        I = self._complement(self._clip01(x))
+        if self.weights:
+            T = self._choices(I)
+            rho = self.vigilance
+            order = list(np.argsort(T)[::-1])
+            for j in order:
+                m = self._match(I, self.weights[j])
+                if m >= rho:
+                    if self.labels[j] == label:
+                        # resonance with correct label -> learn
+                        self.weights[j] = (self.beta * np.minimum(I, self.weights[j])
+                                           + (1.0 - self.beta) * self.weights[j])
+                        return j
+                    else:
+                        # label conflict -> match tracking: raise vigilance just
+                        # above this match so this (and any equally-matching)
+                        # wrong-label node is rejected, then keep searching.
+                        rho = m + 1e-6
+        # no acceptable resonant category -> commit a new one
+        self.weights.append(I.copy())
+        self.labels.append(label)
+        return len(self.weights) - 1
+
+    def fit(self, X, y, epochs=1):
+        for _ in range(epochs):
+            for x, label in zip(X, y):
+                self.train_one(x, label)
+        return self
+
+    @property
+    def n_categories(self):
+        return len(self.weights)

--- a/rate/ARTSelfCheck.py
+++ b/rate/ARTSelfCheck.py
@@ -1,0 +1,102 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+
+from rate.ARTClassifier import FuzzyART, REJECT
+from rate.StructuredInput import ImageFolderInputSet, StructuredInputSet
+
+'''
+Self-check for the standalone Fuzzy ART classifier. Runnable directly and
+pytest-discoverable. Verifies the ART primitives, supervised match tracking, and
+the person/horse classification-with-reject behaviour that the secondary
+cortical area relies on. Uses the real labeled images when the dataset path is
+available, otherwise falls back to synthetic class-distinct patterns so the
+check always runs.
+'''
+
+DATASET = os.environ.get(
+    "CLASSIFIED_STIMULI",
+    "/tmp/claude-0/-home-user-SerotoninModelOne/ed5d92d2-51a2-577d-b9fd-f0759f1ad51a/scratchpad/classified_stimuli/classified_stimuli")
+VIGILANCE = 0.75
+
+
+def _load_dataset():
+    if os.path.isdir(DATASET):
+        data = ImageFolderInputSet(DATASET, gridSize=10, audioBins=20, imagesPerClass=10, seed=0)
+        src = "real images (%s)" % ", ".join(data.classNames)
+    else:
+        # synthetic fallback: 3 classes x a few jittered exemplars
+        data = StructuredInputSet(gridSize=10, audioBins=20, classCount=3, seed=0)
+        src = "synthetic patterns"
+    X = [st.visual for st in data.stimuli]
+    y = [st.label for st in data.stimuli]
+    return X, y, src
+
+
+def test_art_primitives():
+    art = FuzzyART(dim=4, vigilance=0.5, alpha=0.01, beta=1.0)
+    x = np.array([1.0, 0.0, 1.0, 0.0])
+    I = art._complement(art._clip01(x))
+    assert np.allclose(I, [1, 0, 1, 0, 0, 1, 0, 1])   # complement coding
+    assert abs(np.sum(I) - art.dim) < 1e-9            # |I| == dim always
+    # First example commits a category equal to its own complement code.
+    j = art.train_one(x, label="A")
+    assert j == 0 and art.n_categories == 1
+    assert art.classify(x) == "A"                     # exact match classifies
+    # Full match value is 1.0 for the identical input.
+    _, (cat, m) = art.classify(x, return_detail=True)
+    assert cat == 0 and abs(m - 1.0) < 1e-9
+    print("[1] ART primitives (complement coding, |I|=dim, choice/match) OK")
+
+
+def test_match_tracking():
+    # Two identical inputs with different labels must land in SEPARATE
+    # categories (ARTMAP match tracking), and each must classify to its label.
+    art = FuzzyART(dim=4, vigilance=0.6, alpha=0.01, beta=1.0)
+    x = np.array([1.0, 1.0, 0.0, 0.0])
+    art.train_one(x, label="A")
+    art.train_one(x, label="B")
+    assert art.n_categories == 2, art.n_categories
+    # The most-recently-learned same pattern is ambiguous by design; assert both
+    # labels exist among categories and a clean A-only pattern maps to A.
+    assert set(art.labels) == {"A", "B"}
+    print("[2] match tracking: conflicting labels force distinct categories OK")
+
+
+def test_classify_and_reject():
+    X, y, src = _load_dataset()
+    labels = sorted(set(y))
+    art = FuzzyART(dim=len(X[0]), vigilance=VIGILANCE, alpha=0.01, beta=1.0)
+    art.fit(X, y, epochs=1)
+
+    acc = np.mean([art.classify(x) == l for x, l in zip(X, y)])
+    assert acc == 1.0, ("training accuracy", acc)
+    assert set(art.labels) >= set(labels), (art.labels, labels)
+    assert art.n_categories >= len(labels)
+
+    rng = np.random.RandomState(1)
+    noise_rej = np.mean([art.classify(rng.rand(len(X[0]))) == REJECT for _ in range(10)])
+    blank_rej = art.classify(np.zeros(len(X[0]))) == REJECT
+    assert noise_rej == 1.0, ("noise reject rate", noise_rej)
+    assert blank_rej, "blank should be rejected"
+
+    # Content-specific top-down template is a valid [0,1] pattern.
+    t = art.category_template(0)
+    assert t.shape == (len(X[0]),) and t.min() >= 0.0 and t.max() <= 1.0
+
+    print("[3] classify+reject on %s: acc=%.0f%%, ncat=%d, noise+blank rejected OK"
+          % (src, 100 * acc, art.n_categories))
+
+
+def main():
+    test_art_primitives()
+    test_match_tracking()
+    test_classify_and_reject()
+    print("\nAll ART self-checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/CellTypes.py
+++ b/rate/CellTypes.py
@@ -1,0 +1,37 @@
+"""
+Single source of truth for the rate model's per-cell-type transfer functions
+and membrane time constants.
+
+The transfer coefficients (k, theta, n) below were fit by
+rate/fit_transfer_functions.py to the steady-state f-I curves of the
+Izhikevich-2007 cells (see that file for the important note about the 2003/2007
+integration mismatch in the spiking model). Re-run that script to regenerate
+them; the values here should match its output.
+
+Transfer function (steady-state firing rate as a function of total input
+current I, in spikes/sec):
+
+    F(I) = k * max(I - theta, 0) ** n
+
+Membrane time constants tau_m set how fast a cell's rate relaxes toward F(I):
+
+    tau_m * dr/dt = -r + F(I)
+
+They are chosen from typical cortical values (FS cells fastest), not fit, and
+are exposed here so they can be tuned in one place.
+"""
+
+CELL_TYPES = {
+    "Pyramidal": {"k": 0.082284, "theta": 59.51, "n": 0.82971, "tau_m": 20.0},
+    "FS":        {"k": 0.61624,  "theta": 57.604, "n": 0.94659, "tau_m": 10.0},
+    "LTS":       {"k": 0.083716, "theta": 42.616, "n": 1.0089,  "tau_m": 15.0},
+}
+
+
+def transfer(cell_type, I):
+    """Steady-state rate F(I) = k*[I-theta]_+^n for the named cell type."""
+    p = CELL_TYPES[cell_type]
+    x = I - p["theta"]
+    if x <= 0:
+        return 0.0
+    return p["k"] * (x ** p["n"])

--- a/rate/Classifiers.py
+++ b/rate/Classifiers.py
@@ -1,0 +1,243 @@
+import numpy as np
+
+from rate.ARTClassifier import FuzzyART, REJECT
+
+'''
+Switchable downstream classifier for the v3.1 experiment. One interface, three
+backends selected at run time (classifierType):
+
+  FUZZY_ART     unsupervised fuzzy ART: choice/match/vigilance, slow recode,
+                commits new categories via the vigilance test. The scientific
+                default -- new (e.g. audio-driven) categories can self-organise.
+  FUZZY_ARTMAP  supervised at pretrain (labelled map via match tracking), then
+                slow UNSUPERVISED recode during the trial (no labels available
+                in a deprivation trial). Comparison backend.
+  KNN           online nearest-prototype / k-means-style clusterer: prototypes
+                start from pretrain, the nearest drifts toward each input by the
+                learning rate, and an input far from every prototype (a distance
+                "vigilance") spawns a new one. Comparison backend.
+
+Common interface:
+  pretrain(X, y)         initial (labelled) training on clean-V1 features
+  observe(x) -> (cluster, label, confidence)   classify WITHOUT learning
+  learn(x)               one slow UNSUPERVISED update (drift / spawn)
+  n_clusters             current number of categories/prototypes
+  cluster_to_class       dict cluster-index -> majority pretrain class (or REJECT)
+
+All three can spawn new clusters and drift, so emergence of new categories is
+possible in each; only the mechanism differs. `label` is the pretrain-majority
+class of the assigned cluster (REJECT for a novel/too-weak assignment), so the
+same hallucination / emergence metrics apply regardless of backend.
+'''
+
+FUZZY_ART = "FUZZY_ART"
+FUZZY_ARTMAP = "FUZZY_ARTMAP"
+KNN = "KNN"
+KINDS = (FUZZY_ART, FUZZY_ARTMAP, KNN)
+
+
+def make_classifier(kind, dim, learningRate, vigilance=0.75,
+                    activityFloor=0.05, knnDistanceVigilance=0.30, seed=0):
+    if kind == FUZZY_ART:
+        return UnsupervisedFuzzyART(dim, beta=learningRate, vigilance=vigilance,
+                                    activityFloor=activityFloor)
+    if kind == FUZZY_ARTMAP:
+        return SupervisedFuzzyARTMAP(dim, beta=learningRate, vigilance=vigilance,
+                                     activityFloor=activityFloor)
+    if kind == KNN:
+        return OnlineKNN(dim, learningRate=learningRate,
+                         distanceVigilance=knnDistanceVigilance,
+                         activityFloor=activityFloor, seed=seed)
+    raise ValueError("Unknown classifierType %r (expected one of %s)" % (kind, KINDS))
+
+
+def _majority_map(cluster_ids, labels):
+    # cluster index -> most common pretrain class label seen in that cluster.
+    from collections import Counter, defaultdict
+    votes = defaultdict(Counter)
+    for c, y in zip(cluster_ids, labels):
+        votes[c][y] += 1
+    return {c: cnt.most_common(1)[0][0] for c, cnt in votes.items()}
+
+
+class _ARTBase:
+    """Shared plumbing over a FuzzyART instance (complement coding, choice/match,
+    activity gate, cluster->class majority map)."""
+
+    def __init__(self, dim, beta, vigilance, activityFloor):
+        self.kind = None
+        self.dim = int(dim)
+        self.art = FuzzyART(dim=dim, vigilance=vigilance, alpha=0.01,
+                            beta=float(beta), activity_floor=activityFloor)
+        self.cluster_to_class = {}
+
+    @property
+    def n_clusters(self):
+        return self.art.n_categories
+
+    def _too_weak(self, x01):
+        af = self.art.activity_floor
+        return af is not None and float(np.mean(x01)) < af
+
+    def _best_resonant(self, I):
+        # (cluster index, match) of the best category passing vigilance, else
+        # (None, best_match_overall).
+        if not self.art.weights:
+            return None, 0.0
+        T = self.art._choices(I)
+        best_match = 0.0
+        for j in np.argsort(T)[::-1]:
+            m = self.art._match(I, self.art.weights[j])
+            best_match = max(best_match, m)
+            if m >= self.art.vigilance:
+                return int(j), float(m)
+        return None, float(best_match)
+
+    def observe(self, x):
+        x01 = self.art._clip01(x)
+        if self._too_weak(x01):
+            return (REJECT, REJECT, 0.0)
+        I = self.art._complement(x01)
+        j, m = self._best_resonant(I)
+        if j is None:
+            return (REJECT, REJECT, m)
+        return (j, self.cluster_to_class.get(j, REJECT), m)
+
+    def _recode_or_commit(self, x):
+        # Unsupervised: learn into the best resonant category, else commit a new
+        # one. Returns the cluster index touched.
+        x01 = self.art._clip01(x)
+        if self._too_weak(x01):
+            return None
+        I = self.art._complement(x01)
+        j, _ = self._best_resonant(I)
+        if j is None:
+            self.art.weights.append(I.copy())
+            self.art.labels.append(None)
+            return self.art.n_categories - 1
+        beta = self.art.beta
+        self.art.weights[j] = beta * np.minimum(I, self.art.weights[j]) + (1 - beta) * self.art.weights[j]
+        return j
+
+    def learn(self, x):
+        self._recode_or_commit(x)
+
+    def snapshot(self):
+        return {"n_clusters": self.n_clusters,
+                "cluster_to_class": dict(self.cluster_to_class)}
+
+
+class UnsupervisedFuzzyART(_ARTBase):
+    def __init__(self, dim, beta, vigilance, activityFloor):
+        super().__init__(dim, beta, vigilance, activityFloor)
+        self.kind = FUZZY_ART
+
+    def pretrain(self, X, y):
+        # Unsupervised clustering of the pretrain features, then label each
+        # resulting cluster by the majority true class that landed in it.
+        assigned = []
+        for x in X:
+            assigned.append(self._recode_or_commit(x))
+        # a second no-learn pass gives stable final-cluster assignments to map
+        final = [self.observe(x)[0] for x in X]
+        self.cluster_to_class = _majority_map(
+            [c for c in final if c != REJECT],
+            [yy for c, yy in zip(final, y) if c != REJECT])
+        return self
+
+
+class SupervisedFuzzyARTMAP(_ARTBase):
+    def __init__(self, dim, beta, vigilance, activityFloor):
+        super().__init__(dim, beta, vigilance, activityFloor)
+        self.kind = FUZZY_ARTMAP
+
+    def pretrain(self, X, y):
+        # Supervised ARTMAP training (match tracking on labels).
+        for x, label in zip(X, y):
+            self.art.train_one(x, label)
+        # cluster i already carries its trained label
+        self.cluster_to_class = {i: lbl for i, lbl in enumerate(self.art.labels)}
+        return self
+
+    def learn(self, x):
+        # Trial-time learning has no labels -> slow unsupervised recode of the
+        # existing (labelled) categories; a genuinely novel input commits a new,
+        # unlabelled cluster (label REJECT until/unless it acquires structure).
+        j = self._recode_or_commit(x)
+        if j is not None and j not in self.cluster_to_class:
+            self.cluster_to_class[j] = REJECT
+
+
+class OnlineKNN:
+    """Online nearest-prototype clusterer (k-means-style with vigilance spawning).
+
+    Not lazy k-NN: prototypes are maintained online so the model can drift and
+    grow like the ART backends. Nearest prototype -> cluster; that prototype's
+    pretrain-majority class -> label. learn() moves the nearest prototype toward
+    the input by learningRate, or spawns a new prototype if the input is farther
+    than distanceVigilance (in normalized feature distance) from all of them.
+    """
+
+    def __init__(self, dim, learningRate, distanceVigilance, activityFloor, seed=0):
+        self.kind = KNN
+        self.dim = int(dim)
+        self.eta = float(learningRate)
+        self.dvig = float(distanceVigilance)
+        self.activity_floor = None if activityFloor is None else float(activityFloor)
+        self.protos = []                 # list of length-dim vectors in [0,1]
+        self.cluster_to_class = {}
+        self.rng = np.random.RandomState(seed)
+
+    @property
+    def n_clusters(self):
+        return len(self.protos)
+
+    def _clip01(self, x):
+        x = np.asarray(x, dtype=float).ravel()
+        return np.clip(x, 0.0, 1.0)
+
+    def _nearest(self, x01):
+        # (index, normalized distance) of nearest prototype; dist in [0,1] via
+        # RMS over dims so distanceVigilance is grid-size independent.
+        if not self.protos:
+            return None, 1.0
+        d = [np.sqrt(np.mean((x01 - p) ** 2)) for p in self.protos]
+        j = int(np.argmin(d))
+        return j, float(d[j])
+
+    def _too_weak(self, x01):
+        return self.activity_floor is not None and float(np.mean(x01)) < self.activity_floor
+
+    def pretrain(self, X, y):
+        # Seed one prototype per class (class-mean feature); label by that class.
+        X = [self._clip01(x) for x in X]
+        classes = sorted(set(y))
+        for c in classes:
+            mean = np.mean([x for x, yy in zip(X, y) if yy == c], axis=0)
+            self.protos.append(mean.copy())
+            self.cluster_to_class[len(self.protos) - 1] = c
+        return self
+
+    def observe(self, x):
+        x01 = self._clip01(x)
+        if self._too_weak(x01):
+            return (REJECT, REJECT, 0.0)
+        j, d = self._nearest(x01)
+        if j is None:
+            return (REJECT, REJECT, 0.0)
+        conf = max(0.0, 1.0 - d)
+        return (j, self.cluster_to_class.get(j, REJECT), conf)
+
+    def learn(self, x):
+        x01 = self._clip01(x)
+        if self._too_weak(x01):
+            return
+        j, d = self._nearest(x01)
+        if j is None or d > self.dvig:
+            self.protos.append(x01.copy())          # spawn a new prototype
+            return
+        self.protos[j] = self.protos[j] + self.eta * (x01 - self.protos[j])
+
+    def snapshot(self):
+        return {"n_clusters": self.n_clusters,
+                "cluster_to_class": dict(self.cluster_to_class)}

--- a/rate/DemoHallucination.py
+++ b/rate/DemoHallucination.py
@@ -48,6 +48,11 @@ def main():
     ap.add_argument("--images", default=None)
     ap.add_argument("--gains", type=float, nargs="+", default=[1, 2, 4, 8])
     ap.add_argument("--settle", type=float, default=400.0, help="top-down render settle (ms)")
+    ap.add_argument("--render-label", type=int, default=None,
+                    help="force rendering this class label's category (skips the 4-epoch "
+                         "experiment; use when the return epoch rejects, as it does at 10x10)")
+    ap.add_argument("--images-per-class", type=int, default=5)
+    ap.add_argument("--pretrain-settle", type=float, default=200.0)
     ap.add_argument("--stamp", default=None)
     args = ap.parse_args()
 
@@ -56,10 +61,11 @@ def main():
     params["epochDurationMs"] = args.epoch
     params["warmupMs"] = args.warmup
     params["useART"] = True
+    params["artPretrainSettleMs"] = args.pretrain_settle
 
     if args.images:
         data = ImageFolderInputSet(args.images, gridSize=args.grid, audioBins=params["audioBins"],
-                                   imagesPerClass=5, seed=0,
+                                   imagesPerClass=args.images_per_class, seed=0,
                                    minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
         names = data.classNames
     else:
@@ -69,23 +75,36 @@ def main():
         names = [str(i) for i in range(2)]
     stim = data.stimuli[0]
 
-    print("Running %s ART experiment (grid=%d) to obtain the return-epoch percept..."
-          % (args.mode, args.grid))
+    # Build the simulation (this pre-trains the ART classifier on the V1
+    # representations). Run the 4-epoch experiment only when we need the
+    # return-epoch decision; skip it when a class label is forced.
     sim = RetinotopicGrandPlanSimulation(params, stim, data, mode=args.mode, plasticityEnabled=True)
-    sim.run()
     net, art = sim.network, sim.art
 
-    # Modal winning ART category during the return epoch (epoch index 3).
-    tau, dur = params["tau"], params["epochDurationMs"]
-    s, e = int(3 * dur / tau), int(4 * dur / tau)
-    cats = [c for c in sim.artCategory[s:e] if c is not None]
-    if not cats:
-        print("Return epoch rejected throughout; no stable percept to render.")
-        return
-    win = Counter(cats).most_common(1)[0][0]
-    winName = names[art.labels[win]]
-    print("Return-epoch percept: category %d = '%s' (true stimulus '%s')"
-          % (win, winName, names[stim.label]))
+    if args.render_label is not None:
+        cands = [j for j, lab in enumerate(art.labels) if lab == args.render_label]
+        if not cands:
+            print("No ART category with label %d." % args.render_label)
+            return
+        win = cands[0]
+        winName = names[art.labels[win]]
+        print("Rendering forced category %d = '%s' (skipping experiment); true stimulus '%s'"
+              % (win, winName, names[stim.label]))
+    else:
+        print("Running %s ART experiment (grid=%d) to obtain the return-epoch percept..."
+              % (args.mode, args.grid))
+        sim.run()
+        tau, dur = params["tau"], params["epochDurationMs"]
+        s, e = int(3 * dur / tau), int(4 * dur / tau)
+        cats = [c for c in sim.artCategory[s:e] if c is not None]
+        if not cats:
+            print("Return epoch rejected throughout; no stable percept to render.\n"
+                  "Re-run with --render-label to render a chosen class's percept directly.")
+            return
+        win = Counter(cats).most_common(1)[0][0]
+        winName = names[art.labels[win]]
+        print("Return-epoch percept: category %d = '%s' (true stimulus '%s')"
+              % (win, winName, names[stim.label]))
 
     template = art.category_template(win)
     percepts = [net.renderTopDownPercept(template, settleMs=args.settle, gain=g) for g in args.gains]

--- a/rate/DemoHallucination.py
+++ b/rate/DemoHallucination.py
@@ -1,0 +1,119 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import argparse
+import random
+from collections import Counter
+from datetime import datetime
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from rate.RetinotopicGrandPlanParams import buildGrandPlanParams
+from rate.RetinotopicGrandPlanSimulation import RetinotopicGrandPlanSimulation
+from rate.StructuredInput import ImageFolderInputSet, StructuredInputSet
+
+'''
+Visualize the "hallucination": the percept that TOP-DOWN feedback alone paints on
+V1. We run the ART sensory-loss experiment (which, after remapping, stably
+recognizes the wrong category -- "person" for a horse stimulus), take the ART
+category recognized during the RETURN epoch, and drive V1 with ONLY that
+category's top-down template (bottom-up disconnected -- Sulfaro's sensory
+disconnection), sweeping the top-down synaptic gain.
+
+At the influence the model actually exhibits (gain x1) the percept is faint (top-
+down is diluted by the normalized mixture -- Sulfaro's account of why imagery is
+dim); amplified, the hallucinated category emerges vividly on V1, and its spatial
+structure is the (mis)recognized category, not the veridical stimulus.
+
+Usage:
+  python3 rate/DemoHallucination.py --grid 10 --cpc 8 --mode blind \
+      --images <classified_stimuli/classified_stimuli> --gains 1 2 4 8
+'''
+
+FIG_DIR = os.path.join(os.curdir, "figures", "rate_grandplan")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--grid", type=int, default=10)
+    ap.add_argument("--cpc", type=int, default=8)
+    ap.add_argument("--epoch", type=int, default=500)
+    ap.add_argument("--warmup", type=int, default=300)
+    ap.add_argument("--mode", choices=["scotoma", "blind"], default="blind")
+    ap.add_argument("--images", default=None)
+    ap.add_argument("--gains", type=float, nargs="+", default=[1, 2, 4, 8])
+    ap.add_argument("--settle", type=float, default=400.0, help="top-down render settle (ms)")
+    ap.add_argument("--stamp", default=None)
+    args = ap.parse_args()
+
+    random.seed(0); np.random.seed(0)
+    params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
+    params["epochDurationMs"] = args.epoch
+    params["warmupMs"] = args.warmup
+    params["useART"] = True
+
+    if args.images:
+        data = ImageFolderInputSet(args.images, gridSize=args.grid, audioBins=params["audioBins"],
+                                   imagesPerClass=5, seed=0,
+                                   minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
+        names = data.classNames
+    else:
+        data = StructuredInputSet(gridSize=args.grid, audioBins=params["audioBins"],
+                                  classCount=2, seed=0,
+                                  minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
+        names = [str(i) for i in range(2)]
+    stim = data.stimuli[0]
+
+    print("Running %s ART experiment (grid=%d) to obtain the return-epoch percept..."
+          % (args.mode, args.grid))
+    sim = RetinotopicGrandPlanSimulation(params, stim, data, mode=args.mode, plasticityEnabled=True)
+    sim.run()
+    net, art = sim.network, sim.art
+
+    # Modal winning ART category during the return epoch (epoch index 3).
+    tau, dur = params["tau"], params["epochDurationMs"]
+    s, e = int(3 * dur / tau), int(4 * dur / tau)
+    cats = [c for c in sim.artCategory[s:e] if c is not None]
+    if not cats:
+        print("Return epoch rejected throughout; no stable percept to render.")
+        return
+    win = Counter(cats).most_common(1)[0][0]
+    winName = names[art.labels[win]]
+    print("Return-epoch percept: category %d = '%s' (true stimulus '%s')"
+          % (win, winName, names[stim.label]))
+
+    template = art.category_template(win)
+    percepts = [net.renderTopDownPercept(template, settleMs=args.settle, gain=g) for g in args.gains]
+    print("percept mean Hz by gain:", dict(zip(args.gains, [round(float(p.mean()), 2) for p in percepts])))
+
+    G = args.grid
+    ncol = 2 + len(args.gains)
+    fig, ax = plt.subplots(1, ncol, figsize=(3.2 * ncol, 3.5))
+    ax[0].imshow(stim.visualGrid, cmap="magma"); ax[0].set_title("veridical input\n(%s)" % names[stim.label], fontsize=9)
+    ax[1].imshow(template.reshape(G, G), cmap="magma", vmin=0, vmax=1)
+    ax[1].set_title("ART '%s' template\n(top-down feedback)" % winName, fontsize=9)
+    vmax = max(1e-6, max(p.max() for p in percepts))
+    for a, g, p in zip(ax[2:], args.gains, percepts):
+        im = a.imshow(p, cmap="viridis", vmin=0, vmax=vmax)
+        a.set_title("V1 hallucination\ntop-down x%g" % g, fontsize=9)
+    for a in ax:
+        a.set_xticks([]); a.set_yticks([])
+    fig.colorbar(im, ax=ax[2:].tolist(), fraction=0.02, pad=0.01, label="Hz")
+    fig.suptitle("Pure top-down percept: what V1 renders under the '%s' hallucination (%s)"
+                 % (winName, args.mode), y=1.03)
+
+    stamp = args.stamp or datetime.utcnow().isoformat()
+    outdir = os.path.join(FIG_DIR, stamp, args.mode)
+    os.makedirs(outdir, exist_ok=True)
+    path = os.path.join(outdir, "hallucination.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    print("wrote", path)
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/DemoRatePharma.py
+++ b/rate/DemoRatePharma.py
@@ -1,0 +1,56 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import random
+from datetime import datetime
+
+import numpy as np
+
+from rate.RateTwoColumnParams import buildDefaultParams
+from rate.RatePharmaSimulation import RatePharmaSimulation
+from rate.plotting import plot_rates, plot_influence, plot_weights
+
+'''
+Runs the rate pharmacological (5HT2A-agonist / psilocybin) simulation and writes
+the same three figure types as the sensory-loss demo, over the pharma protocol's
+three epochs (baseline / 5HT2A agonism + weak plasticity / return). Mean-only:
+the deterministic rate model captures the mean pharmacological behaviour (Input
+alpha keeps its dominant influence) but not the paper's variability finding.
+
+Usage: python3 rate/DemoRatePharma.py
+'''
+
+FIG_DIR = os.path.join(os.curdir, "figures", "rate_pharma")
+
+
+def main():
+    random.seed(1)
+    np.random.seed(1)
+    params = buildDefaultParams()
+
+    outdir = os.path.join(FIG_DIR, datetime.utcnow().isoformat())
+    os.makedirs(outdir, exist_ok=True)
+
+    print("Running rate pharmacological (5HT2A-agonist) simulation "
+          "(popCount=%d, epoch=%dms)..." % (params["popCount"], params["epochDurationMs"]))
+    sim = RatePharmaSimulation(params)
+    sim.run()
+
+    tau = params["tau"]
+    paths = [
+        plot_rates(sim, outdir, tau, "rate_pharma",
+                   "Rate model: region-A activity across pharmacological (5HT2A-agonist) epochs"),
+        plot_influence(sim, outdir, tau, "rate_pharma",
+                       "Relative influence of Inputs alpha/beta on alpha pyramidal firing (pharma, leave-one-out)"),
+        plot_weights(sim, outdir, tau, "rate_pharma",
+                     "Cross-modal S_B -> P_A weight under 5HT2A agonism (bounded)"),
+    ]
+    print("Wrote:")
+    for p in paths:
+        print("  " + p)
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/DemoRateTwoColumn.py
+++ b/rate/DemoRateTwoColumn.py
@@ -7,116 +7,21 @@ import random
 from datetime import datetime
 
 import numpy as np
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 
 from rate.RateTwoColumnParams import buildDefaultParams
 from rate.RateTwoColumnSimulation import RateTwoColumnSimulation
+from rate.plotting import plot_rates, plot_influence, plot_weights
 
 '''
-Runs the rate two-region sensory-loss simulation and writes paper-style
-figures for validating the rate reformulation against the methods draft:
-
-  rate_twocolumn_rates.png   - region-A firing rates (Input / Pyramidal / FS /
-                               LTS) across the four epochs, matching the draft's
-                               Figure "Neural activity in sensory loss
-                               simulations" layout.
-  rate_twocolumn_influence.png - relative influence of Input alpha (negative)
-                               vs Input beta (positive) on alpha pyramidal
-                               firing, matching the draft's "Relative influence"
-                               figure. Beta's influence should rise in epoch 3
-                               and persist into epoch 4.
-  rate_twocolumn_weights.png - mean remapping-synapse (S_B -> P_A) weight over
-                               time, showing bounded potentiation locked in
-                               during epoch 3.
+Runs the rate two-region sensory-loss simulation and writes paper-style figures
+validating the rate reformulation against the methods draft: region-A firing
+rates across the four epochs, the leave-one-out relative influence of Input
+alpha vs beta on P_alpha, and the bounded remapping-synapse potentiation.
 
 Usage: python3 rate/DemoRateTwoColumn.py
 '''
 
 FIG_DIR = os.path.join(os.curdir, "figures", "rate_twocolumn")
-
-
-def smooth(series, win_ms, tau):
-    # Boxcar smoothing with edge-extension (mode="nearest"), NOT zero-padding.
-    # np.convolve(mode="same") zero-pads the ends, which drags the first/last
-    # ~half-window of samples toward zero and creates a spurious ramp at t=0 in
-    # otherwise-flat traces; uniform_filter1d(mode="nearest") holds the edge
-    # value instead.
-    from scipy.ndimage import uniform_filter1d
-    n = max(1, int(win_ms / tau))
-    s = np.asarray(series, dtype=float)
-    if len(s) < n:
-        return s
-    return uniform_filter1d(s, size=n, mode="nearest")
-
-
-def epoch_lines(ax, boundaries):
-    for b in boundaries[:-1]:
-        ax.axvline(b, color="0.6", ls="--", lw=1)
-
-
-def plot_rates(sim, outdir, tau):
-    boundaries = sim.epochBoundaries
-    pops = [("InputA", "Sensory Input (S_alpha)"),
-            ("pyramidalsA", "Pyramidal (P_alpha)"),
-            ("fastSpikingsA", "Fast Spiking (F_alpha)"),
-            ("lowThresholdsA", "Low-Threshold Spiking (L_alpha)")]
-    fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
-    for ax, (pop, title) in zip(axes, pops):
-        rec = sim.network.populations[pop].rateRecord
-        t = np.arange(len(rec)) * tau
-        ax.plot(t, smooth(rec, 20.0, tau), color="C0")
-        ax.set_title(title, loc="left", fontsize=10)
-        ax.set_ylabel("Rate (Hz)")
-        epoch_lines(ax, boundaries)
-    axes[-1].set_xlabel("Time (ms)")
-    fig.suptitle("Rate model: region-A activity across sensory-loss epochs")
-    fig.tight_layout()
-    path = os.path.join(outdir, "rate_twocolumn_rates.png")
-    fig.savefig(path, dpi=110)
-    plt.close(fig)
-    return path
-
-
-def plot_influence(sim, outdir, tau):
-    pa = sim.network.populations["pyramidalsA"]
-    inputA = sim.network.populations["InputA"]
-    inputB = sim.network.populations["InputB"]
-    # Leave-one-out ablation influence of each input on P_alpha's commanded rate.
-    infA = np.array(pa.ablationInfluence[inputA])
-    infB = np.array(pa.ablationInfluence[inputB])
-    t = np.arange(len(infA)) * tau
-    fig, ax = plt.subplots(figsize=(9, 4))
-    ax.plot(t, -smooth(infA, 20.0, tau), color="C3", label="Input alpha (own, plotted negative)")
-    ax.plot(t, smooth(infB, 20.0, tau), color="C0", label="Input beta (cross-modal, positive)")
-    ax.axhline(0, color="0.7", lw=0.8)
-    epoch_lines(ax, sim.epochBoundaries)
-    ax.set_xlabel("Time (ms)")
-    ax.set_ylabel("Ablation influence on P_alpha rate (Hz)")
-    ax.set_title("Relative influence of Inputs alpha/beta on alpha pyramidal firing (leave-one-out)")
-    ax.legend(fontsize="small")
-    fig.tight_layout()
-    path = os.path.join(outdir, "rate_twocolumn_influence.png")
-    fig.savefig(path, dpi=110)
-    plt.close(fig)
-    return path
-
-
-def plot_weights(sim, outdir, tau):
-    w = sim.weightHistory
-    t = np.arange(len(w)) * tau
-    fig, ax = plt.subplots(figsize=(9, 4))
-    ax.plot(t, w, color="C2")
-    epoch_lines(ax, sim.epochBoundaries)
-    ax.set_xlabel("Time (ms)")
-    ax.set_ylabel("Mean remapping weight (S_B -> P_A)")
-    ax.set_title("Cross-modal remapping synapse potentiation (bounded)")
-    fig.tight_layout()
-    path = os.path.join(outdir, "rate_twocolumn_weights.png")
-    fig.savefig(path, dpi=110)
-    plt.close(fig)
-    return path
 
 
 def main():
@@ -133,9 +38,14 @@ def main():
     sim.run()
 
     tau = params["tau"]
-    paths = [plot_rates(sim, outdir, tau),
-             plot_influence(sim, outdir, tau),
-             plot_weights(sim, outdir, tau)]
+    paths = [
+        plot_rates(sim, outdir, tau, "rate_twocolumn",
+                   "Rate model: region-A activity across sensory-loss epochs"),
+        plot_influence(sim, outdir, tau, "rate_twocolumn",
+                       "Relative influence of Inputs alpha/beta on alpha pyramidal firing (leave-one-out)"),
+        plot_weights(sim, outdir, tau, "rate_twocolumn",
+                     "Cross-modal remapping synapse potentiation (bounded)"),
+    ]
     print("Wrote:")
     for p in paths:
         print("  " + p)

--- a/rate/DemoRateTwoColumn.py
+++ b/rate/DemoRateTwoColumn.py
@@ -75,8 +75,11 @@ def plot_rates(sim, outdir, tau):
 
 def plot_influence(sim, outdir, tau):
     pa = sim.network.populations["pyramidalsA"]
-    infA = np.array(sim.network.populations["InputA"].influenceRecord[pa])
-    infB = np.array(sim.network.populations["InputB"].influenceRecord[pa])
+    inputA = sim.network.populations["InputA"]
+    inputB = sim.network.populations["InputB"]
+    # Leave-one-out ablation influence of each input on P_alpha's commanded rate.
+    infA = np.array(pa.ablationInfluence[inputA])
+    infB = np.array(pa.ablationInfluence[inputB])
     t = np.arange(len(infA)) * tau
     fig, ax = plt.subplots(figsize=(9, 4))
     ax.plot(t, -smooth(infA, 20.0, tau), color="C3", label="Input alpha (own, plotted negative)")
@@ -84,8 +87,8 @@ def plot_influence(sim, outdir, tau):
     ax.axhline(0, color="0.7", lw=0.8)
     epoch_lines(ax, sim.epochBoundaries)
     ax.set_xlabel("Time (ms)")
-    ax.set_ylabel("Driving-factor influence")
-    ax.set_title("Relative influence of Inputs alpha/beta on alpha pyramidal firing")
+    ax.set_ylabel("Ablation influence on P_alpha rate (Hz)")
+    ax.set_title("Relative influence of Inputs alpha/beta on alpha pyramidal firing (leave-one-out)")
     ax.legend(fontsize="small")
     fig.tight_layout()
     path = os.path.join(outdir, "rate_twocolumn_influence.png")

--- a/rate/DemoRateTwoColumn.py
+++ b/rate/DemoRateTwoColumn.py
@@ -38,11 +38,17 @@ FIG_DIR = os.path.join(os.curdir, "figures", "rate_twocolumn")
 
 
 def smooth(series, win_ms, tau):
+    # Boxcar smoothing with edge-extension (mode="nearest"), NOT zero-padding.
+    # np.convolve(mode="same") zero-pads the ends, which drags the first/last
+    # ~half-window of samples toward zero and creates a spurious ramp at t=0 in
+    # otherwise-flat traces; uniform_filter1d(mode="nearest") holds the edge
+    # value instead.
+    from scipy.ndimage import uniform_filter1d
     n = max(1, int(win_ms / tau))
-    if len(series) < n:
-        return np.asarray(series, dtype=float)
-    kernel = np.ones(n) / n
-    return np.convolve(np.asarray(series, dtype=float), kernel, mode="same")
+    s = np.asarray(series, dtype=float)
+    if len(s) < n:
+        return s
+    return uniform_filter1d(s, size=n, mode="nearest")
 
 
 def epoch_lines(ax, boundaries):

--- a/rate/DemoRateTwoColumn.py
+++ b/rate/DemoRateTwoColumn.py
@@ -1,0 +1,136 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import random
+from datetime import datetime
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from rate.RateTwoColumnParams import buildDefaultParams
+from rate.RateTwoColumnSimulation import RateTwoColumnSimulation
+
+'''
+Runs the rate two-region sensory-loss simulation and writes paper-style
+figures for validating the rate reformulation against the methods draft:
+
+  rate_twocolumn_rates.png   - region-A firing rates (Input / Pyramidal / FS /
+                               LTS) across the four epochs, matching the draft's
+                               Figure "Neural activity in sensory loss
+                               simulations" layout.
+  rate_twocolumn_influence.png - relative influence of Input alpha (negative)
+                               vs Input beta (positive) on alpha pyramidal
+                               firing, matching the draft's "Relative influence"
+                               figure. Beta's influence should rise in epoch 3
+                               and persist into epoch 4.
+  rate_twocolumn_weights.png - mean remapping-synapse (S_B -> P_A) weight over
+                               time, showing bounded potentiation locked in
+                               during epoch 3.
+
+Usage: python3 rate/DemoRateTwoColumn.py
+'''
+
+FIG_DIR = os.path.join(os.curdir, "figures", "rate_twocolumn")
+
+
+def smooth(series, win_ms, tau):
+    n = max(1, int(win_ms / tau))
+    if len(series) < n:
+        return np.asarray(series, dtype=float)
+    kernel = np.ones(n) / n
+    return np.convolve(np.asarray(series, dtype=float), kernel, mode="same")
+
+
+def epoch_lines(ax, boundaries):
+    for b in boundaries[:-1]:
+        ax.axvline(b, color="0.6", ls="--", lw=1)
+
+
+def plot_rates(sim, outdir, tau):
+    boundaries = sim.epochBoundaries
+    pops = [("InputA", "Sensory Input (S_alpha)"),
+            ("pyramidalsA", "Pyramidal (P_alpha)"),
+            ("fastSpikingsA", "Fast Spiking (F_alpha)"),
+            ("lowThresholdsA", "Low-Threshold Spiking (L_alpha)")]
+    fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
+    for ax, (pop, title) in zip(axes, pops):
+        rec = sim.network.populations[pop].rateRecord
+        t = np.arange(len(rec)) * tau
+        ax.plot(t, smooth(rec, 20.0, tau), color="C0")
+        ax.set_title(title, loc="left", fontsize=10)
+        ax.set_ylabel("Rate (Hz)")
+        epoch_lines(ax, boundaries)
+    axes[-1].set_xlabel("Time (ms)")
+    fig.suptitle("Rate model: region-A activity across sensory-loss epochs")
+    fig.tight_layout()
+    path = os.path.join(outdir, "rate_twocolumn_rates.png")
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    return path
+
+
+def plot_influence(sim, outdir, tau):
+    pa = sim.network.populations["pyramidalsA"]
+    infA = np.array(sim.network.populations["InputA"].influenceRecord[pa])
+    infB = np.array(sim.network.populations["InputB"].influenceRecord[pa])
+    t = np.arange(len(infA)) * tau
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, -smooth(infA, 20.0, tau), color="C3", label="Input alpha (own, plotted negative)")
+    ax.plot(t, smooth(infB, 20.0, tau), color="C0", label="Input beta (cross-modal, positive)")
+    ax.axhline(0, color="0.7", lw=0.8)
+    epoch_lines(ax, sim.epochBoundaries)
+    ax.set_xlabel("Time (ms)")
+    ax.set_ylabel("Driving-factor influence")
+    ax.set_title("Relative influence of Inputs alpha/beta on alpha pyramidal firing")
+    ax.legend(fontsize="small")
+    fig.tight_layout()
+    path = os.path.join(outdir, "rate_twocolumn_influence.png")
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    return path
+
+
+def plot_weights(sim, outdir, tau):
+    w = sim.weightHistory
+    t = np.arange(len(w)) * tau
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, w, color="C2")
+    epoch_lines(ax, sim.epochBoundaries)
+    ax.set_xlabel("Time (ms)")
+    ax.set_ylabel("Mean remapping weight (S_B -> P_A)")
+    ax.set_title("Cross-modal remapping synapse potentiation (bounded)")
+    fig.tight_layout()
+    path = os.path.join(outdir, "rate_twocolumn_weights.png")
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    return path
+
+
+def main():
+    random.seed(1)
+    np.random.seed(1)
+    params = buildDefaultParams()
+
+    outdir = os.path.join(FIG_DIR, datetime.utcnow().isoformat())
+    os.makedirs(outdir, exist_ok=True)
+
+    print("Running rate two-region sensory-loss simulation "
+          "(popCount=%d, epoch=%dms)..." % (params["popCount"], params["epochDurationMs"]))
+    sim = RateTwoColumnSimulation(params)
+    sim.run()
+
+    tau = params["tau"]
+    paths = [plot_rates(sim, outdir, tau),
+             plot_influence(sim, outdir, tau),
+             plot_weights(sim, outdir, tau)]
+    print("Wrote:")
+    for p in paths:
+        print("  " + p)
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/DemoRetinotopicGrandPlan.py
+++ b/rate/DemoRetinotopicGrandPlan.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from rate.RetinotopicGrandPlanParams import buildGrandPlanParams
 from rate.RetinotopicGrandPlanSimulation import RetinotopicGrandPlanSimulation
-from rate.StructuredInput import StructuredInputSet
+from rate.StructuredInput import StructuredInputSet, ImageFolderInputSet
 from rate.plotting_grandplan import plot_experiment, epoch_means, EPOCH_LABELS
 
 '''
@@ -65,18 +65,28 @@ def main():
     ap.add_argument("--epoch", type=int, default=500)
     ap.add_argument("--warmup", type=int, default=200)
     ap.add_argument("--mode", choices=["both", "scotoma", "blind"], default="both")
+    ap.add_argument("--images", default=None,
+                    help="root folder of labeled image subfolders (person/ horse/); "
+                         "if omitted, synthetic class-distinct patterns are used")
+    ap.add_argument("--stamp", default=None, help="output subdir name (default: UTC timestamp)")
     args = ap.parse_args()
 
     params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
     params["epochDurationMs"] = args.epoch
     params["warmupMs"] = args.warmup
 
-    data = StructuredInputSet(gridSize=args.grid, audioBins=params["audioBins"],
-                              classCount=2, seed=0,
-                              minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
+    if args.images:
+        data = ImageFolderInputSet(args.images, gridSize=args.grid, audioBins=params["audioBins"],
+                                   imagesPerClass=1, seed=0,
+                                   minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
+        print("Using real images from %s: classes %s" % (args.images, data.classNames))
+    else:
+        data = StructuredInputSet(gridSize=args.grid, audioBins=params["audioBins"],
+                                  classCount=2, seed=0,
+                                  minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
     stim = data.stimuli[0]
 
-    stamp = datetime.utcnow().isoformat()
+    stamp = args.stamp or datetime.utcnow().isoformat()
     modes = ["scotoma", "blind"] if args.mode == "both" else [args.mode]
 
     for mode in modes:

--- a/rate/DemoRetinotopicGrandPlan.py
+++ b/rate/DemoRetinotopicGrandPlan.py
@@ -102,6 +102,10 @@ def main():
                     help="phase 3 uses the literature-grounded Realistic-5HT mechanism "
                          "(reduce 5HT in deprived V1 -> higher gain; raise 5HT on cross-modal "
                          "audio input; lower plasticity threshold) instead of a uniform 5HT step")
+    ap.add_argument("--emergent-5ht", action="store_true",
+                    help="closed-loop version: the only imposed event is the sensory loss; a "
+                         "homeostatic controller drives all responses from the activity deficit. "
+                         "Reduces the plasticity rate 10x (pair with longer --epoch).")
     args = ap.parse_args()
 
     params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
@@ -109,6 +113,9 @@ def main():
     params["warmupMs"] = args.warmup
     params["useART"] = args.art
     params["realistic5HT"] = args.realistic_5ht
+    params["emergent5HT"] = args.emergent_5ht
+    if args.emergent_5ht:
+        params["gamma_p"] = params["gamma_p"] / 10.0   # >=10x lower plasticity rate
     if args.pretrain_settle is not None:
         params["artPretrainSettleMs"] = args.pretrain_settle
 

--- a/rate/DemoRetinotopicGrandPlan.py
+++ b/rate/DemoRetinotopicGrandPlan.py
@@ -94,18 +94,24 @@ def main():
     ap.add_argument("--stamp", default=None, help="output subdir name (default: UTC timestamp)")
     ap.add_argument("--art", action="store_true",
                     help="use the Fuzzy ART secondary area (classify/reject + content-specific top-down)")
+    ap.add_argument("--images-per-class", type=int, default=5,
+                    help="ART training exemplars per class (only used with --art/--images)")
+    ap.add_argument("--pretrain-settle", type=float, default=None,
+                    help="ART pre-training settle per image (ms); default from params")
     args = ap.parse_args()
 
     params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
     params["epochDurationMs"] = args.epoch
     params["warmupMs"] = args.warmup
     params["useART"] = args.art
+    if args.pretrain_settle is not None:
+        params["artPretrainSettleMs"] = args.pretrain_settle
 
     if args.images:
         # Load several exemplars per class so the ART classifier has something to
         # learn; the experiment itself uses stimuli[0] as the held stimulus.
         data = ImageFolderInputSet(args.images, gridSize=args.grid, audioBins=params["audioBins"],
-                                   imagesPerClass=5, seed=0,
+                                   imagesPerClass=args.images_per_class, seed=0,
                                    minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
         print("Using real images from %s: classes %s (%d exemplars)"
               % (args.images, data.classNames, len(data.stimuli)))

--- a/rate/DemoRetinotopicGrandPlan.py
+++ b/rate/DemoRetinotopicGrandPlan.py
@@ -1,0 +1,96 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import argparse
+import random
+from datetime import datetime
+
+import numpy as np
+
+from rate.RetinotopicGrandPlanParams import buildGrandPlanParams
+from rate.RetinotopicGrandPlanSimulation import RetinotopicGrandPlanSimulation
+from rate.StructuredInput import StructuredInputSet
+from rate.plotting_grandplan import plot_experiment, epoch_means, EPOCH_LABELS
+
+'''
+Runs the retinotopic grand-plan sensory-loss experiment for both loss modes
+(scotoma and full blindness), each paired with a no-plasticity control, and
+writes the rate / stream-current / remapping-weight figures plus a text summary.
+
+Usage:
+  python3 rate/DemoRetinotopicGrandPlan.py [--grid 6] [--cpc 6] [--epoch 500]
+                                           [--warmup 200] [--mode both|scotoma|blind]
+
+Grid defaults to 6 for a runnable first look; the target architecture is 10.
+'''
+
+FIG_DIR = os.path.join(os.curdir, "figures", "rate_grandplan")
+
+
+def run_condition(params, data, stim, mode, plasticity):
+    random.seed(0); np.random.seed(0)
+    sim = RetinotopicGrandPlanSimulation(params, stim, data, mode=mode,
+                                         plasticityEnabled=plasticity)
+    return sim.run()
+
+
+def summarize(mode, sim, control):
+    em = epoch_means(sim)
+    emc = epoch_means(control)
+    print("\n=== %s ===" % mode.upper())
+    print("  deprived columns: %d   intact columns: %d"
+          % (sum(sim.deprivedColumns),
+             sum(1 for c in sim.silencedColumns if not c)))
+    hdr = "  %-16s " % "epoch" + " ".join("%10s" % e for e in EPOCH_LABELS)
+    print(hdr)
+    def row(label, vals):
+        print("  %-16s " % label + " ".join("%10.2f" % v for v in vals))
+    row("rate deprived", em["rateDeprived"])
+    row("rate intact", em["rateIntact"])
+    row("visual I", em["visualCurrent"])
+    row("audio I (remap)", em["audioCurrent"])
+    row("top-down I", em["topDownCurrent"])
+    row("remap W", em["remapWeight"])
+    row("remap W (ctrl)", emc["remapWeight"])
+    row("audio I (ctrl)", emc["audioCurrent"])
+    row("rate depr (ctrl)", emc["rateDeprived"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--grid", type=int, default=6)
+    ap.add_argument("--cpc", type=int, default=6)
+    ap.add_argument("--epoch", type=int, default=500)
+    ap.add_argument("--warmup", type=int, default=200)
+    ap.add_argument("--mode", choices=["both", "scotoma", "blind"], default="both")
+    args = ap.parse_args()
+
+    params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
+    params["epochDurationMs"] = args.epoch
+    params["warmupMs"] = args.warmup
+
+    data = StructuredInputSet(gridSize=args.grid, audioBins=params["audioBins"],
+                              classCount=2, seed=0,
+                              minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
+    stim = data.stimuli[0]
+
+    stamp = datetime.utcnow().isoformat()
+    modes = ["scotoma", "blind"] if args.mode == "both" else [args.mode]
+
+    for mode in modes:
+        print("Running %s (grid=%d, cpc=%d, epoch=%dms)..."
+              % (mode, args.grid, args.cpc, args.epoch))
+        sim = run_condition(params, data, stim, mode, plasticity=True)
+        control = run_condition(params, data, stim, mode, plasticity=False)
+        summarize(mode, sim, control)
+        outdir = os.path.join(FIG_DIR, stamp, mode)
+        paths = plot_experiment(sim, control, outdir, mode.capitalize())
+        print("  wrote:")
+        for p in paths:
+            print("    " + p)
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/DemoRetinotopicGrandPlan.py
+++ b/rate/DemoRetinotopicGrandPlan.py
@@ -98,12 +98,17 @@ def main():
                     help="ART training exemplars per class (only used with --art/--images)")
     ap.add_argument("--pretrain-settle", type=float, default=None,
                     help="ART pre-training settle per image (ms); default from params")
+    ap.add_argument("--realistic-5ht", action="store_true",
+                    help="phase 3 uses the literature-grounded Realistic-5HT mechanism "
+                         "(reduce 5HT in deprived V1 -> higher gain; raise 5HT on cross-modal "
+                         "audio input; lower plasticity threshold) instead of a uniform 5HT step")
     args = ap.parse_args()
 
     params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
     params["epochDurationMs"] = args.epoch
     params["warmupMs"] = args.warmup
     params["useART"] = args.art
+    params["realistic5HT"] = args.realistic_5ht
     if args.pretrain_settle is not None:
         params["artPretrainSettleMs"] = args.pretrain_settle
 

--- a/rate/DemoRetinotopicGrandPlan.py
+++ b/rate/DemoRetinotopicGrandPlan.py
@@ -57,6 +57,29 @@ def summarize(mode, sim, control):
     row("audio I (ctrl)", emc["audioCurrent"])
     row("rate depr (ctrl)", emc["rateDeprived"])
 
+    if getattr(sim, "artMatch", None):
+        import numpy as np
+        names = getattr(sim.inputSet, "classNames", None)
+        tau = sim.tau; dur = sim.epochDurationMs
+        def decode(e):
+            s = int(e * dur / tau); en = int((e + 1) * dur / tau)
+            cls = np.asarray(sim.artClass[s:en]); mt = np.asarray(sim.artMatch[s:en])
+            if len(cls) == 0:
+                return "n/a"
+            rej = np.mean(cls < 0)
+            # modal non-reject class
+            nonrej = cls[cls >= 0]
+            if len(nonrej):
+                vals, cnts = np.unique(nonrej, return_counts=True)
+                modal = int(vals[np.argmax(cnts)])
+                mname = names[modal] if names else str(modal)
+            else:
+                mname = "-"
+            return "%s rej%2.0f%% m%.2f" % (mname, 100 * rej, np.nanmean(mt))
+        true = sim.inputSet.classNames[sim.trueLabel] if names else str(sim.trueLabel)
+        print("  %-16s " % ("ART (true=%s)" % true)
+              + " ".join("%10s" % decode(e) for e in range(4)))
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -69,17 +92,23 @@ def main():
                     help="root folder of labeled image subfolders (person/ horse/); "
                          "if omitted, synthetic class-distinct patterns are used")
     ap.add_argument("--stamp", default=None, help="output subdir name (default: UTC timestamp)")
+    ap.add_argument("--art", action="store_true",
+                    help="use the Fuzzy ART secondary area (classify/reject + content-specific top-down)")
     args = ap.parse_args()
 
     params = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=2)
     params["epochDurationMs"] = args.epoch
     params["warmupMs"] = args.warmup
+    params["useART"] = args.art
 
     if args.images:
+        # Load several exemplars per class so the ART classifier has something to
+        # learn; the experiment itself uses stimuli[0] as the held stimulus.
         data = ImageFolderInputSet(args.images, gridSize=args.grid, audioBins=params["audioBins"],
-                                   imagesPerClass=1, seed=0,
+                                   imagesPerClass=5, seed=0,
                                    minRateHz=params["minRateHz"], maxRateHz=params["maxRateHz"])
-        print("Using real images from %s: classes %s" % (args.images, data.classNames))
+        print("Using real images from %s: classes %s (%d exemplars)"
+              % (args.images, data.classNames, len(data.stimuli)))
     else:
         data = StructuredInputSet(gridSize=args.grid, audioBins=params["audioBins"],
                                   classCount=2, seed=0,

--- a/rate/EmergentPlotAll.py
+++ b/rate/EmergentPlotAll.py
@@ -26,6 +26,8 @@ def load(path):
     with open(path, "rb") as fh:
         blob = pickle.load(fh)
     sim = types.SimpleNamespace(**blob)
+    # plot_art reads sim.inputSet.classNames; give it a light shim.
+    sim.inputSet = types.SimpleNamespace(classNames=blob.get("classNames"))
     return sim
 
 

--- a/rate/EmergentPlotAll.py
+++ b/rate/EmergentPlotAll.py
@@ -1,0 +1,71 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pickle
+import types
+
+import numpy as np
+
+from rate.plotting_grandplan import plot_experiment, epoch_means
+
+'''
+Load the four EmergentRunOne pickles (scotoma/blind x plasticity/control),
+pair each mode's plasticity run with its no-plasticity control, and regenerate
+the emergent figures (rates / streams / remap_weight / v1_maps / homeostatic)
+plus a compact per-epoch text summary. ART panels are skipped automatically:
+these runs carry no artMatch (classifier kept separate).
+
+Usage: python3 rate/EmergentPlotAll.py <pkl_dir> <out_dir>
+  expects pkl_dir/{scotoma,blind}_{plast,ctrl}.pkl
+'''
+
+
+def load(path):
+    with open(path, "rb") as fh:
+        blob = pickle.load(fh)
+    sim = types.SimpleNamespace(**blob)
+    return sim
+
+
+def main():
+    pkl_dir = sys.argv[1]
+    out_dir = sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+
+    for mode in ("scotoma", "blind"):
+        plast_path = os.path.join(pkl_dir, "%s_plast.pkl" % mode)
+        ctrl_path = os.path.join(pkl_dir, "%s_ctrl.pkl" % mode)
+        if not os.path.exists(plast_path):
+            print("missing %s -- skipping mode %s" % (plast_path, mode))
+            continue
+        sim = load(plast_path)
+        control = load(ctrl_path) if os.path.exists(ctrl_path) else None
+        title = "Emergent 5HT (%s)" % mode
+        outdir = os.path.join(out_dir, mode)
+        paths = plot_experiment(sim, control, outdir, title)
+        print("\n=== %s ===" % title)
+        for p in paths:
+            print("  wrote", p)
+
+        # compact per-epoch text summary
+        em = epoch_means(sim)
+        print("  per-epoch means (plasticity run):")
+        print("    %-14s %8s %8s %8s %8s" %
+              ("field", "baseline", "loss", "epoch3", "return"))
+        for name in ("rateDeprived", "audioCurrent", "topDownCurrent", "remapWeight"):
+            vals = em[name]
+            print("    %-14s %8.2f %8.2f %8.2f %8.2f" % (name, *vals))
+        h = np.asarray(sim.homeostaticDrive, dtype=float)
+        rate = np.asarray(sim.rateDeprived, dtype=float)
+        if sim.A_set:
+            post = rate[len(rate) // 4:]  # after baseline epoch
+            print("    A_set=%.2f  trough=%.2f  peak=%.2f  final=%.2f  h_peak=%.2f h_final=%.2f  W_final=%.1f"
+                  % (sim.A_set, float(np.nanmin(post)), float(np.nanmax(post)),
+                     float(rate[-1]), float(np.nanmax(h)), float(h[-1]),
+                     float(sim.remapWeight[-1])))
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/EmergentRunOne.py
+++ b/rate/EmergentRunOne.py
@@ -15,17 +15,21 @@ from rate.StructuredInput import ImageFolderInputSet
 Run ONE emergent (option-B) sensory-loss simulation (one mode x one plasticity
 condition) and pickle its recorded data, so the four sims of the experiment can
 run as independent parallel processes (each ~90 min at 5000 ms epochs) rather
-than sequentially. ART is OFF here (classifier kept separate per the current
-plan); the emergent RATE trajectory is ART-independent.
+than sequentially. ART (the secondary-area classifier + top-down feedback) is
+OFF by default and enabled with the optional [art] flag; when on, the ART
+decision/match series are recorded too, so the hallucination + resolution
+readout can be plotted over the emergent trajectory.
 
-Usage: python3 rate/EmergentRunOne.py <mode> <plast 0|1> <out.pkl> <images> [grid] [epoch]
+Usage: python3 rate/EmergentRunOne.py <mode> <plast 0|1> <out.pkl> <images> [grid] [epoch] [art 0|1]
 '''
 
 FIELDS = ["tau", "epochDurationMs", "epochBoundaries", "A_set",
           "rateDeprived", "rateIntact", "audioCurrent", "visualCurrent",
           "topDownCurrent", "remapWeight", "homeostaticDrive",
           "v1MapsByEpoch", "inputGrid", "silencedMap", "deprivedMap",
-          "silencedColumns", "deprivedColumns"]
+          "silencedColumns", "deprivedColumns",
+          # ART secondary-area readout (empty lists when ART is off).
+          "artClass", "artReject", "artMatch", "artCategory"]
 
 
 def main():
@@ -35,12 +39,14 @@ def main():
     images = sys.argv[4]
     grid = int(sys.argv[5]) if len(sys.argv) > 5 else 10
     epoch = int(sys.argv[6]) if len(sys.argv) > 6 else 5000
+    art = bool(int(sys.argv[7])) if len(sys.argv) > 7 else False
 
     random.seed(0); np.random.seed(0)
     p = buildGrandPlanParams(gridSize=grid, cellsPerColumn=8, categoryCount=2)
     p["epochDurationMs"] = epoch
     p["warmupMs"] = 300
     p["emergent5HT"] = True
+    p["useART"] = art                           # secondary-area classifier + top-down
     p["gamma_p"] = p["gamma_p"] / 10.0          # >=10x lower plasticity rate
     data = ImageFolderInputSet(images, gridSize=grid, audioBins=p["audioBins"],
                                imagesPerClass=3, seed=0,

--- a/rate/EmergentRunOne.py
+++ b/rate/EmergentRunOne.py
@@ -1,0 +1,65 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pickle
+import random
+import numpy as np
+
+from rate.RetinotopicGrandPlanParams import buildGrandPlanParams
+from rate.RetinotopicGrandPlanSimulation import RetinotopicGrandPlanSimulation
+from rate.StructuredInput import ImageFolderInputSet
+
+'''
+Run ONE emergent (option-B) sensory-loss simulation (one mode x one plasticity
+condition) and pickle its recorded data, so the four sims of the experiment can
+run as independent parallel processes (each ~90 min at 5000 ms epochs) rather
+than sequentially. ART is OFF here (classifier kept separate per the current
+plan); the emergent RATE trajectory is ART-independent.
+
+Usage: python3 rate/EmergentRunOne.py <mode> <plast 0|1> <out.pkl> <images> [grid] [epoch]
+'''
+
+FIELDS = ["tau", "epochDurationMs", "epochBoundaries", "A_set",
+          "rateDeprived", "rateIntact", "audioCurrent", "visualCurrent",
+          "topDownCurrent", "remapWeight", "homeostaticDrive",
+          "v1MapsByEpoch", "inputGrid", "silencedMap", "deprivedMap",
+          "silencedColumns", "deprivedColumns"]
+
+
+def main():
+    mode = sys.argv[1]
+    plast = bool(int(sys.argv[2]))
+    out = sys.argv[3]
+    images = sys.argv[4]
+    grid = int(sys.argv[5]) if len(sys.argv) > 5 else 10
+    epoch = int(sys.argv[6]) if len(sys.argv) > 6 else 5000
+
+    random.seed(0); np.random.seed(0)
+    p = buildGrandPlanParams(gridSize=grid, cellsPerColumn=8, categoryCount=2)
+    p["epochDurationMs"] = epoch
+    p["warmupMs"] = 300
+    p["emergent5HT"] = True
+    p["gamma_p"] = p["gamma_p"] / 10.0          # >=10x lower plasticity rate
+    data = ImageFolderInputSet(images, gridSize=grid, audioBins=p["audioBins"],
+                               imagesPerClass=3, seed=0,
+                               minRateHz=p["minRateHz"], maxRateHz=p["maxRateHz"])
+    sim = RetinotopicGrandPlanSimulation(p, data.stimuli[0], data, mode=mode,
+                                         plasticityEnabled=plast)
+    sim.run()
+
+    blob = {f: getattr(sim, f) for f in FIELDS}
+    blob["params"] = p
+    blob["classNames"] = data.classNames
+    blob["trueLabel"] = data.stimuli[0].label
+    blob["mode"] = mode
+    blob["plasticity"] = plast
+    with open(out, "wb") as fh:
+        pickle.dump(blob, fh)
+    print("wrote %s  (mode=%s plast=%s, deprived final rate=%.2f)"
+          % (out, mode, plast, sim.rateDeprived[-1] if sim.rateDeprived else float("nan")))
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/EmergentRunOne.py
+++ b/rate/EmergentRunOne.py
@@ -47,6 +47,9 @@ def main():
                                minRateHz=p["minRateHz"], maxRateHz=p["maxRateHz"])
     sim = RetinotopicGrandPlanSimulation(p, data.stimuli[0], data, mode=mode,
                                          plasticityEnabled=plast)
+    # Per-cell rate history is unused here and dominates memory (~7 GB at 10x10);
+    # switch it off so the four sims fit and can run in parallel.
+    sim.network.setCellHistoryRecording(False)
 
     def _blob(completedEpoch):
         b = {f: getattr(sim, f) for f in FIELDS}

--- a/rate/EmergentRunOne.py
+++ b/rate/EmergentRunOne.py
@@ -47,16 +47,30 @@ def main():
                                minRateHz=p["minRateHz"], maxRateHz=p["maxRateHz"])
     sim = RetinotopicGrandPlanSimulation(p, data.stimuli[0], data, mode=mode,
                                          plasticityEnabled=plast)
-    sim.run()
 
-    blob = {f: getattr(sim, f) for f in FIELDS}
-    blob["params"] = p
-    blob["classNames"] = data.classNames
-    blob["trueLabel"] = data.stimuli[0].label
-    blob["mode"] = mode
-    blob["plasticity"] = plast
-    with open(out, "wb") as fh:
-        pickle.dump(blob, fh)
+    def _blob(completedEpoch):
+        b = {f: getattr(sim, f) for f in FIELDS}
+        b["params"] = p
+        b["classNames"] = data.classNames
+        b["trueLabel"] = data.stimuli[0].label
+        b["mode"] = mode
+        b["plasticity"] = plast
+        b["completedEpoch"] = completedEpoch      # 4 == full run
+        return b
+
+    def _dump(b, path):
+        tmp = path + ".tmp"
+        with open(tmp, "wb") as fh:
+            pickle.dump(b, fh)
+        os.replace(tmp, path)                      # atomic: a restart can't leave a half-file
+
+    # Resilience: after each epoch, atomically overwrite <out> with the partial
+    # state so a worker restart mid-run loses at most one epoch. The final write
+    # (completedEpoch=4) is identical in shape, so the plotter needs no changes.
+    sim.checkpointFn = lambda s, ep: _dump(_blob(ep), out)
+
+    sim.run()
+    _dump(_blob(4), out)
     print("wrote %s  (mode=%s plast=%s, deprived final rate=%.2f)"
           % (out, mode, plast, sim.rateDeprived[-1] if sim.rateDeprived else float("nan")))
 

--- a/rate/GrandPlanSelfCheck.py
+++ b/rate/GrandPlanSelfCheck.py
@@ -1,0 +1,175 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import random
+import numpy as np
+
+from rate.RetinotopicGrandPlanParams import buildGrandPlanParams
+from rate.RetinotopicGrandPlanNetwork import RetinotopicGrandPlanNetwork
+from rate.StructuredInput import StructuredInputSet, TARGET_AV_CORRELATION
+from rate.NormalizedMixtureNeuron import (
+    NormalizedMixtureNeuron, STREAM_BOTTOMUP, STREAM_TOPDOWN, STREAM_SELF)
+
+'''
+Self-check for the retinotopic grand-plan architecture and its Sulfaro et al.
+(2023) normalized-mixture V1. Runnable directly (python3 rate/GrandPlanSelfCheck.py)
+and discoverable by pytest. Uses a small grid so it runs in a few seconds; the
+target 10x10 architecture is the params default.
+
+Checks:
+  1. Structured input has audio exactly r = 0.25 correlated with visual.
+  2. The V1 mixture neuron is a weight-normalized convex combination of streams.
+  3. The Sulfaro feedforward:feedback knob (wBottomUp:wTopDown) shifts V1's
+     steady-state current between the bottom-up and top-down streams.
+  4. Serotonergic 5HT2A bottom-up gain (Sulfaro's neurochemical bridge) reduces
+     the bottom-up share of V1's drive.
+'''
+
+GRID = 4
+CPC = 6
+
+
+def _steady_state(net, steps):
+    for _ in range(steps):
+        net.step()
+
+
+def _mean_stream_currents(net):
+    # Mean raw (pre-weight) per-stream current across V1 pyramidals, from the
+    # last step's recorded decomposition.
+    cells = net.populations["V1pyr"].cells
+    bu = np.mean([c.lastStreamCurrent[STREAM_BOTTOMUP] for c in cells])
+    td = np.mean([c.lastStreamCurrent[STREAM_TOPDOWN] for c in cells])
+    se = np.mean([c.lastStreamCurrent[STREAM_SELF] for c in cells])
+    mixI = np.mean([c.I for c in cells])
+    return bu, td, se, mixI
+
+
+# ---------------------------------------------------------------------------
+
+def test_structured_input_correlation():
+    for seed in range(5):
+        data = StructuredInputSet(gridSize=GRID, audioBins=20, classCount=2, seed=seed)
+        for st in data.stimuli:
+            r = data.measuredAVCorrelation(st)
+            assert abs(r - TARGET_AV_CORRELATION) < 1e-6, (seed, st.label, r)
+    print("[1] structured input: audio r = 0.25 correlated with visual  (exact) OK")
+
+
+def test_mixture_neuron_convex_combination():
+    tau = 0.1
+
+    class P:
+        def __init__(self, n): self.name = n
+    bu, td, se = P("bu"), P("td"), P("self")
+
+    n = NormalizedMixtureNeuron(tau, "Pyramidal", "t")
+    n.assignStream(bu, STREAM_BOTTOMUP)
+    n.assignStream(td, STREAM_TOPDOWN)
+    n.assignStream(se, STREAM_SELF)
+
+    def inject(a, b, c):
+        n.clearSynapticAccumulators()
+        n.addSynapticTransmission(a, bu)
+        n.addSynapticTransmission(b, td)
+        n.addSynapticTransmission(c, se)
+
+    # Equal weights -> plain mean of the three streams.
+    inject(120.0, 60.0, 30.0); n.step()
+    assert abs(n.I - (120 + 60 + 30) / 3.0) < 1e-9, n.I
+    # Convex combination: mixture current never exceeds the largest stream.
+    assert min(120, 60, 30) - 1e-9 <= n.I <= max(120, 60, 30) + 1e-9
+    # Upweighting a stream moves the mixture toward it.
+    n.streamWeights[STREAM_BOTTOMUP] = 5.0
+    inject(120.0, 60.0, 30.0); n.step()
+    assert n.I > (120 + 60 + 30) / 3.0
+    # Additive offsets (diffuse/external) sit outside the mixture.
+    n.streamWeights[STREAM_BOTTOMUP] = 1.0
+    n.diffuseCurrent = 7.0; n.externalInput = 3.0
+    inject(120.0, 60.0, 30.0); n.step()
+    assert abs(n.I - ((120 + 60 + 30) / 3.0 + 10.0)) < 1e-9, n.I
+    print("[2] mixture neuron: weight-normalized convex combination OK")
+
+
+def test_network_ratio_knob():
+    # With bottom-up and top-down driving V1 to different current levels, the
+    # Sulfaro knob wBottomUp:wTopDown should slide V1's steady mixture current
+    # from the bottom-up level toward the top-down level as the ratio falls.
+    random.seed(0); np.random.seed(0)
+    data = StructuredInputSet(gridSize=GRID, audioBins=20, classCount=2, seed=0,
+                              minRateHz=0.0, maxRateHz=30.0)
+    st = data.stimuli[0]
+
+    ratios = [("bottom-up dominant", 4.0, 1.0),
+              ("equal", 1.0, 1.0),
+              ("top-down dominant", 1.0, 4.0)]
+    mixByRatio = []
+    bu = td = None
+    for label, wB, wT in ratios:
+        random.seed(0); np.random.seed(0)
+        p = buildGrandPlanParams(gridSize=GRID, cellsPerColumn=CPC, categoryCount=2)
+        p["wBottomUp"], p["wTopDown"], p["wSelf"] = wB, wT, 0.0  # isolate the 2 Sulfaro streams
+        net = RetinotopicGrandPlanNetwork(p["tau"], p)
+        net.setVisualRates(data.visualRates(st))
+        net.setAudioRates(data.audioRates(st))
+        # Drive a strong, distinct top-down by injecting current into Category cells.
+        for c in net.populations["Category"].cells:
+            c.setInjectedCurrent(140.0)
+        _steady_state(net, 6000)   # 600 ms
+        b, t, s, mixI = _mean_stream_currents(net)
+        bu, td = b, t
+        mixByRatio.append(mixI)
+        print("    %-20s wB:wT=%.0f:%.0f  bottom-up=%.1f top-down=%.1f  mixI=%.1f"
+              % (label, wB, wT, b, t, mixI))
+
+    assert td > 0 and bu > 0, (bu, td)
+    # Direction of the shift is set by which stream drives the larger current.
+    if bu > td:
+        assert mixByRatio[0] > mixByRatio[1] > mixByRatio[2], mixByRatio
+    else:
+        assert mixByRatio[0] < mixByRatio[1] < mixByRatio[2], mixByRatio
+    print("[3] Sulfaro ratio knob: V1 steady current slides between streams (monotone) OK")
+
+
+def test_serotonin_bottomup_gain():
+    # 5HT2A dampening of bottom-up gain (Sulfaro's bridge) should lower the
+    # bottom-up share of V1's weighted drive.
+    def bottomup_share(gain):
+        random.seed(0); np.random.seed(0)
+        p = buildGrandPlanParams(gridSize=GRID, cellsPerColumn=CPC, categoryCount=2)
+        p["wSelf"] = 0.0
+        net = RetinotopicGrandPlanNetwork(p["tau"], p)
+        data = StructuredInputSet(gridSize=GRID, audioBins=20, classCount=2, seed=0,
+                                  minRateHz=0.0, maxRateHz=30.0)
+        st = data.stimuli[0]
+        net.setVisualRates(data.visualRates(st))
+        net.setAudioRates(data.audioRates(st))
+        for c in net.populations["Category"].cells:
+            c.setInjectedCurrent(140.0)
+        net.setV1BottomUpGain(gain)
+        _steady_state(net, 6000)
+        b, t, s, mixI = _mean_stream_currents(net)
+        # Effective weighted share of bottom-up in the mixture.
+        wB = p["wBottomUp"] * gain
+        wT = p["wTopDown"]
+        return (wB * b) / (wB * b + wT * t)
+
+    full = bottomup_share(1.0)
+    damped = bottomup_share(0.4)
+    print("    bottom-up share: gain=1.0 -> %.3f,  gain=0.4 (5HT2A) -> %.3f" % (full, damped))
+    assert damped < full, (full, damped)
+    print("[4] 5HT2A bottom-up gain: dampening lowers bottom-up share OK")
+
+
+def main():
+    test_structured_input_correlation()
+    test_mixture_neuron_convex_combination()
+    test_network_ratio_knob()
+    test_serotonin_bottomup_gain()
+    print("\nAll grand-plan self-checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/NormalizedMixtureNeuron.py
+++ b/rate/NormalizedMixtureNeuron.py
@@ -168,6 +168,7 @@ class NormalizedMixtureNeuron(RateNeuron):
         self.rate += self.tau * (target - self.rate) / self.tau_m
         if self.rate < 0.0:
             self.rate = 0.0
-        self.rateRecord.append(self.rate)
+        if self.recordCellHistory:
+            self.rateRecord.append(self.rate)
         # synapticInput / synapticInputBySource are cleared by the population
         # after this step (clearSynapticAccumulators), same contract as RateNeuron.

--- a/rate/NormalizedMixtureNeuron.py
+++ b/rate/NormalizedMixtureNeuron.py
@@ -1,0 +1,166 @@
+from rate.RateNeuron import RateNeuron
+
+'''
+V1 (primary visual area) pyramidal neuron implementing the "normalized mixture
+of top-down and bottom-up" from Sulfaro, Robinson & Carlson (2023), "Modelling
+perception as a hierarchical competition differentiates imagined, veridical, and
+hallucinated percepts" (Neuroscience of Consciousness 2023(1):niad018).
+
+------------------------------------------------------------------------------
+The Sulfaro rule
+------------------------------------------------------------------------------
+Sulfaro et al. model perception as a stack of layers, each holding a
+representation matrix r_l. Every unclamped layer updates each timestep as a
+*weighted average* of the layer below (ascending / bottom-up), the layer above
+(descending / top-down), and itself, all at the previous timestep (their
+Fig. 1b, Methods):
+
+                w_{l-1}.pool(r_{l-1}) + w_l.r_l + w_{l+1}.up(r_{l+1})
+     r_l(t)  =  ----------------------------------------------------------
+                             w_{l-1} + w_l + w_{l+1}
+
+The defining feature is the denominator: the combination is normalized by the
+*sum of the stream weights*, making it a convex combination (a weighted mean),
+NOT a plain additive sum. The feedforward-to-feedback weighting ratio
+w_{l-1}/w_{l+1} is the single knob that governs perception: > 1 (bottom-up
+dominant) yields veridical perception; < 1 (top-down dominant) pushes the layer
+toward the hallucinatory / imagined regime (their Fig. 3). Note this is a
+fixed-weight convex combination normalized by constant weights -- it is NOT the
+activity-dependent divisive normalization of Carandini & Heeger.
+
+------------------------------------------------------------------------------
+Why we apply the normalization at the INPUT-CURRENT level (not the rate level)
+------------------------------------------------------------------------------
+Sulfaro operate on abstract representation matrices with no spike/rate/current
+distinction: r is simultaneously "the activity" and "what gets averaged". Our
+model is per-neuron and biophysically grounded: each cell has a total input
+current I and a firing rate r = F(I), where F is the fitted threshold-power-law
+transfer function. There are therefore two places we could insert the
+normalized mixture, and they are NOT equivalent because F is nonlinear:
+
+  (a) current level: normalize the input CURRENTS, then pass the mixed current
+      through the cell's transfer function once --
+          I_V1 = (w_bu.I_bu + w_self.I_self + w_td.I_td) / (w_bu + w_self + w_td)
+          r    = F(I_V1)
+
+  (b) rate level: compute each stream's rate separately and average the RATES --
+          r_V1 = (w_bu.F(I_bu) + w_self.F(I_self) + w_td.F(I_td)) / (sum w)
+
+We use (a), current level, chosen deliberately for three reasons:
+
+  1. It preserves the cell's transfer nonlinearity as a single, physical
+     input-output stage. Option (b) would apply F independently to each stream
+     and then average the outputs, which double-counts the threshold/expansive
+     nonlinearity and discards the fact that a real neuron sums its synaptic
+     currents at the soma before spiking. There is one spike-generating
+     mechanism per cell, so there should be one F per cell.
+
+  2. Sulfaro themselves state (Methods) that their weighted average "is
+     approximately equivalent to the biologically plausible additive
+     combination of neural inputs, followed by a decay of activity proportional
+     to the strength of activation." Additive combination *of neural inputs*
+     (currents) followed by decay is exactly current-level summation feeding a
+     leaky rate variable -- i.e. option (a). So current-level normalization is
+     arguably closer to the biological process they invoke to justify the rule
+     than the literal matrix-of-rates form.
+
+  3. Serotonin's action falls out of machinery we already validated. Sulfaro's
+     own neurochemical bridge (their "Serotonin and acetylcholine..." section;
+     Seillier et al. 2017; Michaiel et al. 2019) is that 5HT2A dampens V1's gain
+     to bottom-up sensory input -- i.e. it lowers w_{l-1}. Because our bottom-up
+     stream is a synaptic current, a serotonergic gain on the bottom-up WEIGHT
+     (self.bottomUpGain) reuses the transmission-gain concept from RateAxon
+     rather than introducing a new bespoke mechanism.
+
+The cost of (a) is that the leave-one-out ablation influence metric
+(RatePopulation.stepCells) assumes I is additive in the per-source currents;
+under normalization the marginal effect of a source is not its raw current, so
+that metric is disabled on mixture populations (trackInfluence=False) rather
+than reported with a wrong additive counterfactual. A normalization-aware
+influence metric can be derived later if needed.
+
+------------------------------------------------------------------------------
+Stream assignment
+------------------------------------------------------------------------------
+Each inbound source population is tagged with the stream it belongs to
+(bottom-up / top-down / self) via assignStream(). RateAxon already attributes
+every injected current to its source population (synapticInputBySource), so we
+regroup those per-source currents into the three streams each step. Sources with
+no explicit assignment default to bottom-up (ascending sensory drive), matching
+Sulfaro's treatment of the lowest layer as the sensory entryway.
+
+Somatic diffuse currents (self.diffuseCurrent, e.g. somatic 5HT1A/5HT2A) and any
+external injected current stay ADDITIVE and outside the mixture: they are
+soma-level offsets/gains, not one of the three representational streams being
+averaged.
+'''
+
+STREAM_BOTTOMUP = "bottomup"
+STREAM_TOPDOWN = "topdown"
+STREAM_SELF = "self"
+STREAMS = (STREAM_BOTTOMUP, STREAM_TOPDOWN, STREAM_SELF)
+
+
+class NormalizedMixtureNeuron(RateNeuron):
+    def __init__(self, tau, cellType, name, parentPop=None,
+                 w_bottomup=1.0, w_topdown=1.0, w_self=1.0):
+        super().__init__(tau, cellType, name, parentPop)
+        # Stream weights. Defaults are all 1.0 -> Sulfaro's neutral scheme
+        # (w_{l-1} = w_l = w_{l+1} = 1). The feedforward:feedback ratio
+        # w_bottomup / w_topdown is the perception knob.
+        self.streamWeights = {
+            STREAM_BOTTOMUP: float(w_bottomup),
+            STREAM_TOPDOWN: float(w_topdown),
+            STREAM_SELF: float(w_self),
+        }
+        # sourcePopulation object -> stream name. Filled by the network builder.
+        self.sourceStream = {}
+        # Multiplicative gain applied to the bottom-up weight only (serotonergic
+        # 5HT2A hook, per Sulfaro's neurochemical bridge). 1.0 = unmodulated.
+        self.bottomUpGain = 1.0
+
+        # Last step's per-stream RAW currents (before weighting/normalization),
+        # recorded for metrics/plots and the normalization self-check.
+        self.lastStreamCurrent = {STREAM_BOTTOMUP: 0.0, STREAM_TOPDOWN: 0.0, STREAM_SELF: 0.0}
+
+    def assignStream(self, sourcePopulation, stream):
+        if stream not in STREAMS:
+            raise ValueError("Unknown stream %r (expected one of %s)" % (stream, STREAMS))
+        self.sourceStream[sourcePopulation] = stream
+
+    def effectiveStreamWeights(self):
+        # Bottom-up weight is scaled by the serotonergic gain; the others are
+        # used as-is. Returned as (w_bu, w_td, w_self).
+        return (self.streamWeights[STREAM_BOTTOMUP] * self.bottomUpGain,
+                self.streamWeights[STREAM_TOPDOWN],
+                self.streamWeights[STREAM_SELF])
+
+    def _mixtureCurrent(self):
+        # Regroup this step's per-source synaptic currents into the three
+        # streams, then take the weight-normalized convex combination.
+        streamCurrent = {STREAM_BOTTOMUP: 0.0, STREAM_TOPDOWN: 0.0, STREAM_SELF: 0.0}
+        for srcPop, current in self.synapticInputBySource.items():
+            stream = self.sourceStream.get(srcPop, STREAM_BOTTOMUP)
+            streamCurrent[stream] += current
+        self.lastStreamCurrent = streamCurrent
+        w_bu, w_td, w_self = self.effectiveStreamWeights()
+        wsum = w_bu + w_td + w_self
+        if wsum <= 0.0:
+            return 0.0
+        return (w_bu * streamCurrent[STREAM_BOTTOMUP]
+                + w_td * streamCurrent[STREAM_TOPDOWN]
+                + w_self * streamCurrent[STREAM_SELF]) / wsum
+
+    def step(self):
+        self.time += self.tau
+        # Sulfaro normalized mixture at the current level (see module docstring):
+        # the synaptic streams are combined by weight-normalized average; somatic
+        # diffuse and external currents remain additive offsets outside the mix.
+        self.I = self.externalInput + self.diffuseCurrent + self._mixtureCurrent()
+        target = self.transfer(self.I)
+        self.rate += self.tau * (target - self.rate) / self.tau_m
+        if self.rate < 0.0:
+            self.rate = 0.0
+        self.rateRecord.append(self.rate)
+        # synapticInput / synapticInputBySource are cleared by the population
+        # after this step (clearSynapticAccumulators), same contract as RateNeuron.

--- a/rate/NormalizedMixtureNeuron.py
+++ b/rate/NormalizedMixtureNeuron.py
@@ -122,6 +122,12 @@ class NormalizedMixtureNeuron(RateNeuron):
         # Last step's per-stream RAW currents (before weighting/normalization),
         # recorded for metrics/plots and the normalization self-check.
         self.lastStreamCurrent = {STREAM_BOTTOMUP: 0.0, STREAM_TOPDOWN: 0.0, STREAM_SELF: 0.0}
+        # Last step's RAW current per SOURCE population. The bottom-up stream
+        # lumps visual and cross-modal audio together (both are ascending, so
+        # both carry the bottom-up weight); this finer breakdown lets an
+        # experiment read the audio (cross-modal) drive separately as the
+        # remapping readout without changing the mixture's stream weighting.
+        self.lastSourceCurrent = {}
 
     def assignStream(self, sourcePopulation, stream):
         if stream not in STREAMS:
@@ -143,6 +149,7 @@ class NormalizedMixtureNeuron(RateNeuron):
             stream = self.sourceStream.get(srcPop, STREAM_BOTTOMUP)
             streamCurrent[stream] += current
         self.lastStreamCurrent = streamCurrent
+        self.lastSourceCurrent = dict(self.synapticInputBySource)
         w_bu, w_td, w_self = self.effectiveStreamWeights()
         wsum = w_bu + w_td + w_self
         if wsum <= 0.0:

--- a/rate/README.md
+++ b/rate/README.md
@@ -1,0 +1,43 @@
+# Rate-based reformulation (`rate/`)
+
+A parallel, per-neuron **firing-rate** reformulation of the spiking serotonin
+model, built to remove the runaway / timestep-quantization behavior of the
+spiking version while staying faithful to the methods draft's mechanisms.
+The spiking model under `model/` is untouched and preserved as the
+"Last Spiking" checkpoint.
+
+## Core pieces
+
+- **`CellTypes.py`** — per-cell-type transfer functions `F(I) = k·[I−θ]₊^n`
+  and membrane time constants. Coefficients are fit by
+  `fit_transfer_functions.py`.
+- **`fit_transfer_functions.py`** — derives the transfer coefficients from the
+  steady-state f-I curves of the Izhikevich cells, using the **Izhikevich-2007**
+  form the cell parameters actually belong to. (The spiking `model/Neuron.py`
+  integrates the older 2003 form with 2007 parameters — a mismatch that makes
+  FS/LTS fire spontaneously at rest and inflates rates into the thousands.
+  Flagged for the paper authors; not "fixed" here since we don't touch the
+  spiking model.)
+- **`RateNeuron.py`** — `RateNeuron` (`τ_m·dr/dt = −r + F(I)`) and
+  `RateInputNeuron` (directly-settable input rate).
+- **`RateAxon.py`** — rate-driven saturating synaptic conductance (AMPA/NMDA/
+  GABA), with **transmission failure rolled into a deterministic effective
+  weight** `w_eff = w·clamp(1−failureRate, 0, 1)`, plus the calcium/NMDA
+  plasticity rule.
+- **`RateDiffuseReceptor.py`** — somatic (adds current) and axonal (scales
+  `w_eff` via failure rate) serotonin receptors.
+- **`RatePopulation.py`** — per-neuron population with connection management,
+  mean-rate and cross-modal-influence recording, two-phase stepping.
+
+## Key properties vs. the spiking model
+
+- **Deterministic** — no stochastic spike failures, so a single run is
+  representative (the spiking model needed 10× runs + confidence intervals to
+  average out that noise).
+- **Bounded** — saturating conductances and a sane transfer function replace
+  the unbounded / quantization-driven spiking dynamics.
+
+## Not yet done
+
+Network/simulation assembly and parameter retuning (the spiking weights were
+tuned against inflated rates and do not carry over directly).

--- a/rate/RateAxon.py
+++ b/rate/RateAxon.py
@@ -64,6 +64,16 @@ class RateAxon:
         self.g_nmda = 0.0
         self.g_gaba = 0.0
 
+        # Precomputed per-axon conductance constants (hoisted out of the per-step
+        # hot loop -- equivalent to the ALPHA[...]/TAU_F[...] dict lookups, just
+        # resolved once). tau is fixed for the life of the axon.
+        self._alpha_ampa = ALPHA["AMPA"]
+        self._alpha_nmda = ALPHA["NMDA"]
+        self._alpha_gaba = ALPHA["GABA"]
+        self._inv_tau_ampa = 1.0 / TAU_F["AMPA"]
+        self._inv_tau_nmda = 1.0 / TAU_F["NMDA"]
+        self._inv_tau_gaba = 1.0 / TAU_F["GABA"]
+
         # Transmission failure, rolled into the effective weight. Axonal 5HT2A
         # receptors modify self.failureRate; getEffectiveWeight() applies it.
         self.baseFailureRate = baseFailureRate
@@ -89,6 +99,13 @@ class RateAxon:
         # injected current to its source for the ablation influence metric).
         self.sourcePopulation = getattr(source, "parentPopulation", None)
 
+        # Cached effective weight w * clamp(1 - failureRate). It changes only
+        # when the failure rate changes (serotonin) or the weight changes
+        # (plasticity), which are rare relative to per-step reads, so we cache it
+        # and refresh at those two points instead of recomputing every step.
+        self._effWeight = 0.0
+        self._recomputeEffWeight()
+
     # ---- transmission gain / failure rollup ----
 
     def getTransmissionGain(self):
@@ -99,8 +116,11 @@ class RateAxon:
             return 1.0
         return gain
 
+    def _recomputeEffWeight(self):
+        self._effWeight = self.weight * self.getTransmissionGain()
+
     def getEffectiveWeight(self):
-        return self.weight * self.getTransmissionGain()
+        return self._effWeight
 
     def enablePlasticity(self, gamma_p, gamma_d, threshold, ceilingFactor=None):
         # Turn on the calcium-based plasticity rule with the given constants.
@@ -128,18 +148,21 @@ class RateAxon:
         # Axonal 5HT2A serotonin lowers the failure rate (raising transmission),
         # matching the spiking AxonalSerotoninReceptor: base - sum(weight*level).
         self.failureRate = self.baseFailureRate - sum(r.weight * r.level for r in self.axonalReceptors)
+        self._recomputeEffWeight()
 
     # ---- per-step dynamics ----
 
     def _updateConductances(self):
-        r = self.source.rate            # presynaptic rate, Hz
-        rms = r / 1000.0                # spikes per ms
+        rms = self.source.rate / 1000.0     # presynaptic rate -> spikes per ms
         h = self.tau
         if self.glutamatergic:
-            self.g_ampa += h * (ALPHA["AMPA"] * rms * (1.0 - self.g_ampa) - self.g_ampa / TAU_F["AMPA"])
-            self.g_nmda += h * (ALPHA["NMDA"] * rms * (1.0 - self.g_nmda) - self.g_nmda / TAU_F["NMDA"])
+            ga = self.g_ampa
+            self.g_ampa = ga + h * (self._alpha_ampa * rms * (1.0 - ga) - ga * self._inv_tau_ampa)
+            gn = self.g_nmda
+            self.g_nmda = gn + h * (self._alpha_nmda * rms * (1.0 - gn) - gn * self._inv_tau_nmda)
         else:
-            self.g_gaba += h * (ALPHA["GABA"] * rms * (1.0 - self.g_gaba) - self.g_gaba / TAU_F["GABA"])
+            gg = self.g_gaba
+            self.g_gaba = gg + h * (self._alpha_gaba * rms * (1.0 - gg) - gg * self._inv_tau_gaba)
 
     def _conductanceSum(self):
         if self.glutamatergic:
@@ -197,3 +220,5 @@ class RateAxon:
             self.weight = 0.0
             self.plasticity = False
             self.pruned = True
+        # Weight changed -> refresh the cached effective weight.
+        self._recomputeEffWeight()

--- a/rate/RateAxon.py
+++ b/rate/RateAxon.py
@@ -1,0 +1,187 @@
+'''
+Rate-based analogue of the spiking model's Axon + postsynaptic conductance
+(GlutGSDReceptor / GABAGSDReceptor).
+
+Two things differ from the spiking axon, both deliberate:
+
+1. Transmission failure is rolled into the weight.
+   In the spiking model each spike is stochastically dropped with probability
+   `failureRate` (Axon.enqueue: transmit only if random() > failureRate), and
+   axonal 5HT2A serotonin lowers that probability. In a rate model there are no
+   discrete spikes to drop, so the *expected* transmitted drive is simply
+   scaled by (1 - failureRate). We therefore carry a deterministic effective
+   weight
+
+       w_eff = weight * clamp(1 - failureRate, 0, 1)
+
+   and axonal 5HT2A receptors raise w_eff by lowering failureRate (clamped so
+   transmission can't exceed 100%, matching the spiking cap of "every spike
+   gets through"). This removes the single largest source of run-to-run noise.
+
+2. Synaptic conductance is driven by presynaptic rate, not spikes.
+   The spiking synapse gates a saturating Q/g system with a per-timestep spike
+   flag K (which the methods draft itself notes is timestep-dependent). The
+   rate reduction replaces K with the presynaptic rate and keeps a single
+   saturating gating variable per receptor type:
+
+       dg/dt = alpha * (r_pre/1000) * (1 - g) - g / tau_f
+
+   with the paper's decay time constants tau_f (AMPA 10 ms, NMDA 100 ms,
+   GABA 30 ms). g is bounded in [0, 1). The rise constants tau_r are collapsed
+   into this single decay-dominated form; the slow NMDA conductance (tau_f =
+   100 ms) is what feeds the calcium/plasticity term, exactly as in the paper.
+
+A synapse is glutamatergic (AMPA + NMDA conductances) when weight > 0 and
+GABAergic (GABA conductance) when weight <= 0, mirroring the spiking model's
+choice of receptor class by weight sign. The sign of the injected current comes
+from w_eff (negative for GABA), so conductances stay non-negative.
+'''
+
+# Decay time constants (ms), from the methods-draft synapse table.
+TAU_F = {"AMPA": 10.0, "NMDA": 100.0, "GABA": 30.0}
+# Release efficacy per receptor (tunable); sets the presynaptic rate at which
+# the conductance half-saturates. Kept uniform by default.
+ALPHA = {"AMPA": 1.0, "NMDA": 1.0, "GABA": 1.0}
+
+BASE_FAILURE_RATE = 0.25
+
+
+class RateAxon:
+    def __init__(self, tau, weight, source, target, baseFailureRate=BASE_FAILURE_RATE):
+        self.tau = tau
+        self.weight = weight
+        self.source = source
+        self.target = target
+
+        source.addOutput(self)
+        target.addInput(self)
+
+        self.glutamatergic = weight > 0
+
+        # Conductance gating variables (non-negative, saturating toward 1).
+        self.g_ampa = 0.0
+        self.g_nmda = 0.0
+        self.g_gaba = 0.0
+
+        # Transmission failure, rolled into the effective weight. Axonal 5HT2A
+        # receptors modify self.failureRate; getEffectiveWeight() applies it.
+        self.baseFailureRate = baseFailureRate
+        self.failureRate = baseFailureRate
+        self.axonalReceptors = []
+
+        # Plasticity (Graupner/Brunel-style calcium rule); off unless enabled.
+        # See _applyPlasticity for the rate reduction of the paper's rule.
+        self.plasticity = False
+        self.gamma_p = 0.0
+        self.gamma_d = 0.0
+        self.threshold = 0.0
+        self.pruned = False
+
+        # Records / diagnostics
+        self.driveFactor = []       # per-step cross-modal driving factor phi
+        self.tempDriveFactor = 0.0
+
+    # ---- transmission gain / failure rollup ----
+
+    def getTransmissionGain(self):
+        gain = 1.0 - self.failureRate
+        if gain < 0.0:
+            return 0.0
+        if gain > 1.0:
+            return 1.0
+        return gain
+
+    def getEffectiveWeight(self):
+        return self.weight * self.getTransmissionGain()
+
+    def enablePlasticity(self, gamma_p, gamma_d, threshold):
+        # Turn on the calcium-based plasticity rule with the given constants.
+        # A synapse already pruned to zero stays pruned (matches the paper).
+        if self.pruned:
+            return
+        self.plasticity = True
+        self.gamma_p = gamma_p
+        self.gamma_d = gamma_d
+        self.threshold = threshold
+
+    def disablePlasticity(self):
+        self.plasticity = False
+
+    def addAxonalReceptor(self, receptor):
+        self.axonalReceptors.append(receptor)
+        receptor.setTarget(self)
+
+    def recomputeFailureRate(self):
+        # Axonal 5HT2A serotonin lowers the failure rate (raising transmission),
+        # matching the spiking AxonalSerotoninReceptor: base - sum(weight*level).
+        self.failureRate = self.baseFailureRate - sum(r.weight * r.level for r in self.axonalReceptors)
+
+    # ---- per-step dynamics ----
+
+    def _updateConductances(self):
+        r = self.source.rate            # presynaptic rate, Hz
+        rms = r / 1000.0                # spikes per ms
+        h = self.tau
+        if self.glutamatergic:
+            self.g_ampa += h * (ALPHA["AMPA"] * rms * (1.0 - self.g_ampa) - self.g_ampa / TAU_F["AMPA"])
+            self.g_nmda += h * (ALPHA["NMDA"] * rms * (1.0 - self.g_nmda) - self.g_nmda / TAU_F["NMDA"])
+        else:
+            self.g_gaba += h * (ALPHA["GABA"] * rms * (1.0 - self.g_gaba) - self.g_gaba / TAU_F["GABA"])
+
+    def _conductanceSum(self):
+        if self.glutamatergic:
+            return self.g_ampa + self.g_nmda
+        return self.g_gaba
+
+    def calciumProxy(self):
+        # Postsynaptic intracellular calcium approximated as NMDA-mediated
+        # conductance scaled by weight (I_ca ~ w * g_NMDA), per the methods draft.
+        return self.getEffectiveWeight() * self.g_nmda
+
+    def step(self):
+        self._updateConductances()
+
+        # Cross-modal driving factor phi (recorded for the "relative influence"
+        # metric): presynaptic-rate-weighted postsynaptic calcium above threshold.
+        if self.glutamatergic:
+            self.tempDriveFactor = (self.source.rate / 1000.0) * max(self.calciumProxy() - self.threshold, 0.0)
+        else:
+            self.tempDriveFactor = 0.0
+        self.driveFactor.append(self.tempDriveFactor)
+
+        if self.plasticity:
+            self._applyPlasticity()
+
+        # Inject current into the postsynaptic neuron for this step.
+        self.target.addSynapticTransmission(self.getEffectiveWeight() * self._conductanceSum())
+
+    def _applyPlasticity(self):
+        # Rate reduction of the methods-draft calcium/STDP rule (Graupner &
+        # Brunel 2012 style). The paper updates weight on each presynaptic
+        # spike:
+        #   LTP: dw = gamma_p * [I_ca - Th]_+ * (eligibility over recent post spikes)
+        #   LTD: dw = -gamma_d                       (per presynaptic spike)
+        # with I_ca ~ w_eff * g_NMDA. Presynaptic spikes arrive at rate r_pre;
+        # the post-spike eligibility trace exp((t_post - t_pre)/tau_p) averages,
+        # in rate form, to something proportional to the postsynaptic rate
+        # r_post. So the expected weight change per unit time is:
+        #
+        #   dw/dt = (r_pre/1000) * ( gamma_p * (r_post/1000) * [Ca - Th]_+ - gamma_d )
+        #
+        # Rates in Hz are converted to per-ms so the constants keep sensible
+        # magnitudes. Potentiation therefore requires BOTH pre and post activity
+        # (Hebbian coincidence, carried by r_pre and r_post) plus calcium above
+        # threshold; depression is unconditional on presynaptic drive. A synapse
+        # driven to zero weight is pinned there and pruned, as in the paper.
+        r_pre = self.source.rate
+        r_post = self.target.rate
+        ca_above = self.calciumProxy() - self.threshold
+        if ca_above < 0.0:
+            ca_above = 0.0
+        potentiation = self.gamma_p * (r_post / 1000.0) * ca_above
+        dw = self.tau * (r_pre / 1000.0) * (potentiation - self.gamma_d)
+        self.weight += dw
+        if self.weight <= 0.0:
+            self.weight = 0.0
+            self.plasticity = False
+            self.pruned = True

--- a/rate/RateAxon.py
+++ b/rate/RateAxon.py
@@ -85,14 +85,9 @@ class RateAxon:
         self.plasticityWeightMax = float("inf")
         self.pruned = False
 
-        # Threshold used only by the cross-modal driving-factor *metric* (phi).
-        # Kept fixed (independent of whether/when plasticity is enabled) so the
-        # "relative influence" measurement is comparable across epochs.
-        self.influenceThreshold = 0.0
-
-        # Records / diagnostics
-        self.driveFactor = []       # per-step cross-modal driving factor phi
-        self.tempDriveFactor = 0.0
+        # Cache the source population once (used to attribute this axon's
+        # injected current to its source for the ablation influence metric).
+        self.sourcePopulation = getattr(source, "parentPopulation", None)
 
     # ---- transmission gain / failure rollup ----
 
@@ -159,19 +154,14 @@ class RateAxon:
     def step(self):
         self._updateConductances()
 
-        # Cross-modal driving factor phi (recorded for the "relative influence"
-        # metric): presynaptic-rate-weighted postsynaptic calcium above threshold.
-        if self.glutamatergic:
-            self.tempDriveFactor = (self.source.rate / 1000.0) * max(self.calciumProxy() - self.influenceThreshold, 0.0)
-        else:
-            self.tempDriveFactor = 0.0
-        self.driveFactor.append(self.tempDriveFactor)
-
         if self.plasticity:
             self._applyPlasticity()
 
-        # Inject current into the postsynaptic neuron for this step.
-        self.target.addSynapticTransmission(self.getEffectiveWeight() * self._conductanceSum())
+        # Inject current into the postsynaptic neuron for this step, attributed
+        # to this axon's source population so the target can compute the
+        # leave-one-out ablation influence of each source.
+        self.target.addSynapticTransmission(
+            self.getEffectiveWeight() * self._conductanceSum(), self.sourcePopulation)
 
     def _applyPlasticity(self):
         # Rate reduction of the methods-draft calcium/STDP rule (Graupner &

--- a/rate/RateAxon.py
+++ b/rate/RateAxon.py
@@ -50,6 +50,7 @@ class RateAxon:
     def __init__(self, tau, weight, source, target, baseFailureRate=BASE_FAILURE_RATE):
         self.tau = tau
         self.weight = weight
+        self.initialWeight = weight
         self.source = source
         self.target = target
 
@@ -75,6 +76,13 @@ class RateAxon:
         self.gamma_p = 0.0
         self.gamma_d = 0.0
         self.plasticityThreshold = 0.0
+        # Soft upper bound on the weight (Gütig et al. 2003 / van Rossum et al.
+        # 2000 style): potentiation is scaled by (1 - w/w_max) so LTP smoothly
+        # vanishes as the weight approaches w_max, making the calcium-driven
+        # rule stable instead of diverging (calcium ~ weight is otherwise a
+        # positive-feedback loop). A departure from the paper's unbounded rule,
+        # adopted because bounded stability is the point of the rate model.
+        self.plasticityWeightMax = float("inf")
         self.pruned = False
 
         # Threshold used only by the cross-modal driving-factor *metric* (phi).
@@ -99,15 +107,20 @@ class RateAxon:
     def getEffectiveWeight(self):
         return self.weight * self.getTransmissionGain()
 
-    def enablePlasticity(self, gamma_p, gamma_d, threshold):
+    def enablePlasticity(self, gamma_p, gamma_d, threshold, ceilingFactor=None):
         # Turn on the calcium-based plasticity rule with the given constants.
         # A synapse already pruned to zero stays pruned (matches the paper).
+        # ceilingFactor sets the soft weight ceiling as a multiple of the
+        # synapse's initial weight (w_max = ceilingFactor * initialWeight);
+        # None leaves it unbounded (paper-faithful, but can diverge).
         if self.pruned:
             return
         self.plasticity = True
         self.gamma_p = gamma_p
         self.gamma_d = gamma_d
         self.plasticityThreshold = threshold
+        if ceilingFactor is not None:
+            self.plasticityWeightMax = ceilingFactor * self.initialWeight
 
     def disablePlasticity(self):
         self.plasticity = False
@@ -183,7 +196,11 @@ class RateAxon:
         ca_above = self.calciumProxy() - self.plasticityThreshold
         if ca_above < 0.0:
             ca_above = 0.0
-        potentiation = self.gamma_p * (r_post / 1000.0) * ca_above
+        # Soft upper bound: potentiation fades to zero as weight -> w_max.
+        headroom = 1.0 - self.weight / self.plasticityWeightMax
+        if headroom < 0.0:
+            headroom = 0.0
+        potentiation = self.gamma_p * (r_post / 1000.0) * ca_above * headroom
         dw = self.tau * (r_pre / 1000.0) * (potentiation - self.gamma_d)
         self.weight += dw
         if self.weight <= 0.0:

--- a/rate/RateAxon.py
+++ b/rate/RateAxon.py
@@ -74,8 +74,13 @@ class RateAxon:
         self.plasticity = False
         self.gamma_p = 0.0
         self.gamma_d = 0.0
-        self.threshold = 0.0
+        self.plasticityThreshold = 0.0
         self.pruned = False
+
+        # Threshold used only by the cross-modal driving-factor *metric* (phi).
+        # Kept fixed (independent of whether/when plasticity is enabled) so the
+        # "relative influence" measurement is comparable across epochs.
+        self.influenceThreshold = 0.0
 
         # Records / diagnostics
         self.driveFactor = []       # per-step cross-modal driving factor phi
@@ -102,7 +107,7 @@ class RateAxon:
         self.plasticity = True
         self.gamma_p = gamma_p
         self.gamma_d = gamma_d
-        self.threshold = threshold
+        self.plasticityThreshold = threshold
 
     def disablePlasticity(self):
         self.plasticity = False
@@ -144,7 +149,7 @@ class RateAxon:
         # Cross-modal driving factor phi (recorded for the "relative influence"
         # metric): presynaptic-rate-weighted postsynaptic calcium above threshold.
         if self.glutamatergic:
-            self.tempDriveFactor = (self.source.rate / 1000.0) * max(self.calciumProxy() - self.threshold, 0.0)
+            self.tempDriveFactor = (self.source.rate / 1000.0) * max(self.calciumProxy() - self.influenceThreshold, 0.0)
         else:
             self.tempDriveFactor = 0.0
         self.driveFactor.append(self.tempDriveFactor)
@@ -175,7 +180,7 @@ class RateAxon:
         # driven to zero weight is pinned there and pruned, as in the paper.
         r_pre = self.source.rate
         r_post = self.target.rate
-        ca_above = self.calciumProxy() - self.threshold
+        ca_above = self.calciumProxy() - self.plasticityThreshold
         if ca_above < 0.0:
             ca_above = 0.0
         potentiation = self.gamma_p * (r_post / 1000.0) * ca_above

--- a/rate/RateDiffuseReceptor.py
+++ b/rate/RateDiffuseReceptor.py
@@ -1,0 +1,80 @@
+'''
+Rate-model diffuse serotonin receptors, mirroring the spiking model's
+SomaticSerotoninReceptor / AxonalSerotoninReceptor but deterministic.
+
+Somatic receptors sit on a RateNeuron and contribute a diffuse current
+weight * level to the neuron's total input current I. Axonal receptors sit on a
+RateAxon and shift its transmission failure rate (which is rolled into the
+effective weight, see RateAxon).
+
+Sign conventions follow the *code's* existing parameters, not the methods
+draft's prose (the two disagree on 5HT1A/5HT2A somatic polarity; the retinotopic
+network uses the code's weights, e.g. Somatic5HT2AWeight=+20, so we stay
+weight-sign-agnostic and let the passed-in weight carry the sign).
+'''
+
+
+class RateSomaticReceptor:
+    def __init__(self, typeString, weight, initialLevel=0.0):
+        self.typeString = typeString
+        self.weight = weight
+        self.level = initialLevel
+        self.current = weight * initialLevel
+        self.target = None
+
+    def getTypeString(self):
+        return self.typeString
+
+    def setTarget(self, target):
+        self.target = target
+
+    def setLevel(self, level):
+        self.level = level
+        self.current = self.weight * level
+        if self.target is not None:
+            self.target.recomputeDiffuseCurrent()
+
+
+class RateAxonalReceptor:
+    def __init__(self, typeString, weight, initialLevel=0.0):
+        self.typeString = typeString
+        self.weight = weight
+        self.level = initialLevel
+        self.target = None
+
+    def getTypeString(self):
+        return self.typeString
+
+    def setTarget(self, target):
+        self.target = target
+        if self.target is not None:
+            self.target.recomputeFailureRate()
+
+    def setLevel(self, level):
+        self.level = level
+        if self.target is not None:
+            self.target.recomputeFailureRate()
+
+
+class RateSomaticReceptorFactory:
+    def __init__(self, typeString, weight):
+        self.typeString = typeString
+        self.weight = weight
+
+    def getTypeString(self):
+        return self.typeString
+
+    def constructReceptor(self, initialLevel=0.0):
+        return RateSomaticReceptor(self.typeString, self.weight, initialLevel)
+
+
+class RateAxonalReceptorFactory:
+    def __init__(self, typeString, weight):
+        self.typeString = typeString
+        self.weight = weight
+
+    def getTypeString(self):
+        return self.typeString
+
+    def constructReceptor(self, initialLevel=0.0):
+        return RateAxonalReceptor(self.typeString, self.weight, initialLevel)

--- a/rate/RateNeuron.py
+++ b/rate/RateNeuron.py
@@ -55,6 +55,12 @@ class RateNeuron:
         self.outputs = []
         self.diffuseReceptors = []
 
+        # Per-cell firing-rate history. Nothing in the grand-plan experiment reads
+        # it (metrics use cell.rate live and record their own scalar series), and
+        # at 10x10 x hundreds of thousands of steps it is the dominant memory cost
+        # (~7 GB), so it can be turned off for long runs. Default True preserves
+        # every existing caller / self-check.
+        self.recordCellHistory = True
         self.rateRecord = []
 
     def transfer(self, I):
@@ -94,7 +100,8 @@ class RateNeuron:
         self.rate += self.tau * (target - self.rate) / self.tau_m
         if self.rate < 0.0:
             self.rate = 0.0
-        self.rateRecord.append(self.rate)
+        if self.recordCellHistory:
+            self.rateRecord.append(self.rate)
         # NOTE: synapticInput / synapticInputBySource are NOT cleared here.
         # The population clears them (clearSynapticAccumulators) after computing
         # the ablation influence metric, which needs the per-source breakdown
@@ -115,6 +122,7 @@ class RateInputNeuron:
         self.time = 0.0
         self.inputs = []
         self.outputs = []
+        self.recordCellHistory = True
         self.rateRecord = []
 
     def setRate(self, rate):
@@ -128,4 +136,5 @@ class RateInputNeuron:
 
     def step(self):
         self.time += self.tau
-        self.rateRecord.append(self.rate)
+        if self.recordCellHistory:
+            self.rateRecord.append(self.rate)

--- a/rate/RateNeuron.py
+++ b/rate/RateNeuron.py
@@ -1,0 +1,120 @@
+from rate.CellTypes import CELL_TYPES
+
+'''
+Rate-based analogues of the spiking model's Neuron / PoissonNeuron.
+
+RateNeuron replaces the Izhikevich point neuron with a single firing-rate
+variable r that relaxes toward the cell type's steady-state transfer function:
+
+    tau_m * dr/dt = -r + F(I),     F(I) = k * max(I - theta, 0) ** n
+
+where I is the total input current (synaptic + diffuse serotonin + external),
+and (k, theta, n, tau_m) come from CellTypes for the cell's type.
+
+RateInputNeuron replaces the Poisson spike generator: it has no membrane, just
+a directly-settable rate (the lambda), which its outbound axons read.
+
+Both expose the small interface RatePopulation / the rate axons rely on:
+a `.rate` attribute, `.outputs`, `.addOutput`, `.addInput`, `.parentPopulation`,
+`.rateRecord`, and `.step()`.
+'''
+
+
+class RateNeuron:
+    def __init__(self, tau, cellType, name, parentPop=None):
+        if cellType not in CELL_TYPES:
+            raise ValueError("Unknown cell type %r (expected one of %s)"
+                             % (cellType, list(CELL_TYPES.keys())))
+        self.tau = tau
+        self.type = cellType
+        self.name = name
+        self.parentPopulation = parentPop
+
+        params = CELL_TYPES[cellType]
+        self.k = params["k"]
+        self.theta = params["theta"]
+        self.n = params["n"]
+        self.tau_m = params["tau_m"]
+
+        self.rate = 0.0
+        self.time = 0.0
+
+        # Inputs into total current I, mirroring the spiking Neuron:
+        #   synapticInput  - refreshed every step from inbound rate axons
+        #   diffuseCurrent - set when diffuse serotonin changes, persists
+        #   externalInput  - optional constant injected current
+        self.synapticInput = 0.0
+        self.diffuseCurrent = 0.0
+        self.externalInput = 0.0
+        self.I = 0.0
+
+        self.inputs = []
+        self.outputs = []
+        self.diffuseReceptors = []
+
+        self.rateRecord = []
+
+    def transfer(self, I):
+        x = I - self.theta
+        if x <= 0:
+            return 0.0
+        return self.k * (x ** self.n)
+
+    def addInput(self, axon):
+        self.inputs.append(axon)
+
+    def addOutput(self, axon):
+        self.outputs.append(axon)
+
+    def addSynapticTransmission(self, current):
+        self.synapticInput += current
+
+    def setInjectedCurrent(self, current):
+        self.externalInput = float(current)
+
+    def addDiffuseReceptor(self, receptor):
+        self.diffuseReceptors.append(receptor)
+        receptor.setTarget(self)
+        self.recomputeDiffuseCurrent()
+
+    def recomputeDiffuseCurrent(self):
+        # Diffuse current = sum over somatic serotonin receptors of weight*level.
+        self.diffuseCurrent = sum(r.current for r in self.diffuseReceptors)
+
+    def step(self):
+        self.time += self.tau
+        self.I = self.externalInput + self.synapticInput + self.diffuseCurrent
+        target = self.transfer(self.I)
+        self.rate += self.tau * (target - self.rate) / self.tau_m
+        if self.rate < 0.0:
+            self.rate = 0.0
+        self.rateRecord.append(self.rate)
+        # Synaptic drive is recomputed from scratch each step by the inbound
+        # axons (in the population's output phase), so clear it here.
+        self.synapticInput = 0.0
+
+
+class RateInputNeuron:
+    def __init__(self, tau, rate, name, parentPop=None):
+        self.tau = tau
+        self.type = "RateInput"
+        self.name = name
+        self.parentPopulation = parentPop
+        self.rate = float(rate)
+        self.time = 0.0
+        self.inputs = []
+        self.outputs = []
+        self.rateRecord = []
+
+    def setRate(self, rate):
+        self.rate = float(rate)
+
+    def addInput(self, axon):
+        self.inputs.append(axon)
+
+    def addOutput(self, axon):
+        self.outputs.append(axon)
+
+    def step(self):
+        self.time += self.tau
+        self.rateRecord.append(self.rate)

--- a/rate/RateNeuron.py
+++ b/rate/RateNeuron.py
@@ -44,6 +44,9 @@ class RateNeuron:
         #   diffuseCurrent - set when diffuse serotonin changes, persists
         #   externalInput  - optional constant injected current
         self.synapticInput = 0.0
+        # Per-source-population synaptic current this step, used by the
+        # leave-one-out ablation influence metric (RatePopulation.stepCells).
+        self.synapticInputBySource = {}
         self.diffuseCurrent = 0.0
         self.externalInput = 0.0
         self.I = 0.0
@@ -66,8 +69,11 @@ class RateNeuron:
     def addOutput(self, axon):
         self.outputs.append(axon)
 
-    def addSynapticTransmission(self, current):
+    def addSynapticTransmission(self, current, sourcePopulation=None):
         self.synapticInput += current
+        if sourcePopulation is not None:
+            self.synapticInputBySource[sourcePopulation] = \
+                self.synapticInputBySource.get(sourcePopulation, 0.0) + current
 
     def setInjectedCurrent(self, current):
         self.externalInput = float(current)
@@ -89,9 +95,14 @@ class RateNeuron:
         if self.rate < 0.0:
             self.rate = 0.0
         self.rateRecord.append(self.rate)
-        # Synaptic drive is recomputed from scratch each step by the inbound
-        # axons (in the population's output phase), so clear it here.
+        # NOTE: synapticInput / synapticInputBySource are NOT cleared here.
+        # The population clears them (clearSynapticAccumulators) after computing
+        # the ablation influence metric, which needs the per-source breakdown
+        # that produced this step's self.I. Inbound axons refill them next step.
+
+    def clearSynapticAccumulators(self):
         self.synapticInput = 0.0
+        self.synapticInputBySource = {}
 
 
 class RateInputNeuron:

--- a/rate/RatePharmaSimulation.py
+++ b/rate/RatePharmaSimulation.py
@@ -1,0 +1,54 @@
+from rate.RateSimulationBase import RateSimulationBase
+
+'''
+Three-epoch pharmacological (5HT2A-agonist / psilocybin) simulation on the rate
+two-region network, following the methods draft's pharmacological protocol.
+
+  epoch 1  baseline: both inputs on, serotonin at baseline, plasticity off
+  epoch 2  5HT2A agonism: ONLY 5HT2A raised (to pharma5HT2ALevel) in BOTH
+           regions -- somatic and axonal, 5HT1A left at baseline -- with
+           plasticity on for the cross-modal S_B -> P_A synapses at an
+           order-of-magnitude weaker rate than the sensory experiment
+  epoch 3  return: 5HT2A back to baseline in both regions, plasticity off
+
+Unlike the sensory-loss experiment there is NO sensory loss, so Input alpha
+remains present and Input alpha keeps its dominant influence over P_alpha
+throughout (the paper's mean pharmacological result). Note: the paper's
+headline pharmacological finding is an increase in the *variability* of
+cross-modal influence under 5HT2A agonism; that is a stochastic effect the
+deterministic rate model does not reproduce, so this simulation captures only
+the mean behavior.
+'''
+
+
+class RatePharmaSimulation(RateSimulationBase):
+    def _set_5ht2a_both_regions(self, level5ht2a):
+        base = self.params["serotoninLevelA"]
+        for region in ("A", "B"):
+            self.network.setRegionTransmitters(region, {"5HT2A": level5ht2a, "5HT1A": base})
+
+    def epoch1(self):
+        self.runEpoch(1)
+        self.weightsByEpoch["1_baseline"] = [a.weight for a in self.remapping]
+
+    def epoch2(self):
+        self._set_5ht2a_both_regions(self.params["pharma5HT2ALevel"])
+        for axon in self.remapping:
+            axon.enablePlasticity(self.params["pharma_gamma_p"], self.params["pharma_gamma_d"],
+                                  self.params["plasticityThreshold"],
+                                  ceilingFactor=self.params["plasticityCeilingFactor"])
+        self.runEpoch(2)
+        for axon in self.remapping:
+            axon.disablePlasticity()
+        self.weightsByEpoch["2_5ht2a_agonism"] = [a.weight for a in self.remapping]
+
+    def epoch3(self):
+        self._set_5ht2a_both_regions(self.params["serotoninLevelA"])
+        self.runEpoch(3)
+        self.weightsByEpoch["3_return"] = [a.weight for a in self.remapping]
+
+    def run(self):
+        self.warmup()
+        self.epoch1()
+        self.epoch2()
+        self.epoch3()

--- a/rate/RatePopulation.py
+++ b/rate/RatePopulation.py
@@ -23,7 +23,7 @@ Records kept per step:
 class RatePopulation:
     def __init__(self, tau, cellType, popCount, diffuseSomaReceptorFactories,
                  diffuseTransmitters, parentNetwork, name,
-                 isInput=False, inputRate=0.0):
+                 isInput=False, inputRate=0.0, neuronFactory=None):
         self.tau = tau
         self.cellType = cellType
         self.name = name
@@ -34,11 +34,18 @@ class RatePopulation:
         self.diffuseSomaReceptorFactories = diffuseSomaReceptorFactories or []
         self.diffuseTransmitters = dict(diffuseTransmitters or {})
 
+        # neuronFactory(tau, cellType, name, parentPop) builds each non-input
+        # cell; defaults to a plain RateNeuron. The retinotopic V1 area passes a
+        # factory that returns NormalizedMixtureNeuron so V1 cells combine their
+        # streams by the Sulfaro normalized mixture instead of additive summation.
+        if neuronFactory is None:
+            neuronFactory = lambda tau_, ct, nm, parentPop: RateNeuron(tau_, ct, nm, parentPop=parentPop)
+
         if isInput:
             self.cells = [RateInputNeuron(tau, inputRate, "%s.in.%d" % (name, i), parentPop=self)
                           for i in range(popCount)]
         else:
-            self.cells = [RateNeuron(tau, cellType, "%s.%s.%d" % (name, cellType, i), parentPop=self)
+            self.cells = [neuronFactory(tau, cellType, "%s.%s.%d" % (name, cellType, i), self)
                           for i in range(popCount)]
             for cell in self.cells:
                 for factory in self.diffuseSomaReceptorFactories:

--- a/rate/RatePopulation.py
+++ b/rate/RatePopulation.py
@@ -48,8 +48,17 @@ class RatePopulation:
         self.outboundAxons = []
         self.outboundAxonsByTargetPop = {}
         self.inboundAxons = []
-        self.influenceRecord = {}
         self.rateRecord = []
+
+        # Leave-one-out ablation influence: for each source population S that
+        # projects to this one, ablationInfluence[S] is a per-step time series
+        # of sum_j [ F(I_j) - F(I_j - I_{S->j}) ] over this population's cells j
+        # -- the causal effect of removing S's synaptic current on the commanded
+        # firing rate. Set trackInfluence=False on populations you don't measure
+        # to skip the extra transfer evaluations.
+        self.trackInfluence = not isInput
+        self.ablationInfluence = {}
+        self._inboundSourcePops = None
 
     # ---- construction ----
 
@@ -57,7 +66,6 @@ class RatePopulation:
         axonalReceptorFactories = axonalReceptorFactories or []
         if targetPopulation not in self.outboundAxonsByTargetPop:
             self.outboundAxonsByTargetPop[targetPopulation] = []
-            self.influenceRecord[targetPopulation] = []
         for source in self.cells:
             for target in targetPopulation.cells:
                 weight = weightFunction(source, target)
@@ -92,12 +100,35 @@ class RatePopulation:
 
     # ---- per-step ----
 
+    def _inboundSources(self):
+        if self._inboundSourcePops is None:
+            self._inboundSourcePops = sorted(
+                {a.sourcePopulation for a in self.inboundAxons if a.sourcePopulation is not None},
+                key=lambda p: p.name)
+        return self._inboundSourcePops
+
     def stepCells(self):
         for cell in self.cells:
             cell.step()
         self.rateRecord.append(sum(c.rate for c in self.cells) / len(self.cells))
-        for targetPop, axons in self.outboundAxonsByTargetPop.items():
-            self.influenceRecord[targetPop].append(sum(a.tempDriveFactor for a in axons))
+
+        if self.trackInfluence and not self.isInput:
+            # Leave-one-out ablation influence of each source population S on
+            # this population: sum over cells j of F(I_j) - F(I_j - I_{S->j}).
+            # Difference the commanded rate F(I) (not the membrane-filtered
+            # rate) so it reflects the instantaneous causal effect. Iterate a
+            # fixed source set so every source's series has equal length.
+            for srcPop in self._inboundSources():
+                total = 0.0
+                for cell in self.cells:
+                    iSrc = cell.synapticInputBySource.get(srcPop, 0.0)
+                    if iSrc != 0.0:
+                        total += cell.transfer(cell.I) - cell.transfer(cell.I - iSrc)
+                self.ablationInfluence.setdefault(srcPop, []).append(total)
+
+        if not self.isInput:
+            for cell in self.cells:
+                cell.clearSynapticAccumulators()
 
     def stepOutputs(self):
         for axon in self.outboundAxons:

--- a/rate/RatePopulation.py
+++ b/rate/RatePopulation.py
@@ -1,0 +1,109 @@
+from rate.RateNeuron import RateNeuron, RateInputNeuron
+from rate.RateAxon import RateAxon
+
+'''
+Rate-based analogue of the spiking model's Population, at per-neuron
+granularity. Holds a set of RateNeurons (or RateInputNeurons for an input
+population) and manages the axons that originate in it.
+
+Interface mirrors the spiking Population closely enough that a network builder
+can drive either model with the same connection-construction pattern:
+  - addOutboundConnections(targetPop, weightFn, axonalReceptorFactories)
+  - setDiffuseTransmitters(dict)  /  setRate(rate)  (input pops)
+  - stepCells()  then  stepOutputs()   each timestep
+
+Records kept per step:
+  - rateRecord: mean firing rate across the population
+  - influenceRecord[targetPop]: summed cross-modal driving factor (phi) from
+    this population's excitatory axons onto each target population, the rate
+    analogue of the paper's "relative influence" metric.
+'''
+
+
+class RatePopulation:
+    def __init__(self, tau, cellType, popCount, diffuseSomaReceptorFactories,
+                 diffuseTransmitters, parentNetwork, name,
+                 isInput=False, inputRate=0.0):
+        self.tau = tau
+        self.cellType = cellType
+        self.name = name
+        self.popCount = popCount
+        self.parentNetwork = parentNetwork
+        self.isInput = isInput
+
+        self.diffuseSomaReceptorFactories = diffuseSomaReceptorFactories or []
+        self.diffuseTransmitters = dict(diffuseTransmitters or {})
+
+        if isInput:
+            self.cells = [RateInputNeuron(tau, inputRate, "%s.in.%d" % (name, i), parentPop=self)
+                          for i in range(popCount)]
+        else:
+            self.cells = [RateNeuron(tau, cellType, "%s.%s.%d" % (name, cellType, i), parentPop=self)
+                          for i in range(popCount)]
+            for cell in self.cells:
+                for factory in self.diffuseSomaReceptorFactories:
+                    level = self.diffuseTransmitters.get(factory.getTypeString(), 0.0)
+                    cell.addDiffuseReceptor(factory.constructReceptor(level))
+
+        self.outboundAxons = []
+        self.outboundAxonsByTargetPop = {}
+        self.inboundAxons = []
+        self.influenceRecord = {}
+        self.rateRecord = []
+
+    # ---- construction ----
+
+    def addOutboundConnections(self, targetPopulation, weightFunction, axonalReceptorFactories=None):
+        axonalReceptorFactories = axonalReceptorFactories or []
+        if targetPopulation not in self.outboundAxonsByTargetPop:
+            self.outboundAxonsByTargetPop[targetPopulation] = []
+            self.influenceRecord[targetPopulation] = []
+        for source in self.cells:
+            for target in targetPopulation.cells:
+                weight = weightFunction(source, target)
+                if weight is None:
+                    continue
+                axon = RateAxon(self.tau, weight, source, target)
+                for factory in axonalReceptorFactories:
+                    level = targetPopulation.diffuseTransmitters.get(factory.getTypeString(), 0.0)
+                    axon.addAxonalReceptor(factory.constructReceptor(level))
+                self.outboundAxons.append(axon)
+                self.outboundAxonsByTargetPop[targetPopulation].append(axon)
+                targetPopulation.inboundAxons.append(axon)
+
+    # ---- runtime controls ----
+
+    def setRate(self, rate):
+        for cell in self.cells:
+            cell.setRate(rate)
+
+    def setDiffuseTransmitters(self, diffuseTransmitters):
+        self.diffuseTransmitters = dict(diffuseTransmitters)
+        # Update somatic receptors on this population's neurons.
+        if not self.isInput:
+            for cell in self.cells:
+                for receptor in cell.diffuseReceptors:
+                    receptor.setLevel(self.diffuseTransmitters.get(receptor.getTypeString(), 0.0))
+        # Update axonal receptors on inbound axons (distal serotonin sees the
+        # target region's transmitter levels).
+        for axon in self.inboundAxons:
+            for receptor in axon.axonalReceptors:
+                receptor.setLevel(self.diffuseTransmitters.get(receptor.getTypeString(), 0.0))
+
+    # ---- per-step ----
+
+    def stepCells(self):
+        for cell in self.cells:
+            cell.step()
+        self.rateRecord.append(sum(c.rate for c in self.cells) / len(self.cells))
+        for targetPop, axons in self.outboundAxonsByTargetPop.items():
+            self.influenceRecord[targetPop].append(sum(a.tempDriveFactor for a in axons))
+
+    def stepOutputs(self):
+        for axon in self.outboundAxons:
+            axon.step()
+
+    # ---- plasticity helpers ----
+
+    def outboundAxonsTo(self, targetPopulation):
+        return self.outboundAxonsByTargetPop.get(targetPopulation, [])

--- a/rate/RateSimulationBase.py
+++ b/rate/RateSimulationBase.py
@@ -1,0 +1,60 @@
+import numpy as np
+
+from rate.RateTwoColumnNetwork import RateTwoColumnNetwork
+
+'''
+Shared machinery for the rate two-region experiments (sensory-loss and
+pharmacological). Subclasses define the epoch protocol in run().
+
+Common features:
+  - a warmup period run at baseline before recording, so recorded epochs start
+    from steady state (avoids the startup-overshoot transient in epoch 1);
+  - per-step recording of the mean remapping-synapse (S_B -> P_A) weight;
+  - epoch boundaries for plotting;
+  - weightsByEpoch snapshots keyed by epoch label.
+'''
+
+
+class RateSimulationBase:
+    def __init__(self, params):
+        self.params = params
+        self.tau = params["tau"]
+        self.epochDurationMs = params["epochDurationMs"]
+        self.warmupMs = params.get("warmupMs", 500.0)
+        self.network = RateTwoColumnNetwork(self.tau, params)
+        self.remapping = self.network.remappingAxons()   # S_B -> P_A
+
+        self.weightHistory = []
+        self.epochBoundaries = []
+        self.weightsByEpoch = {}
+
+    def _record_weight(self):
+        if self.remapping:
+            self.weightHistory.append(float(np.mean([a.weight for a in self.remapping])))
+
+    def warmup(self):
+        for _ in np.arange(0.0, self.warmupMs, self.tau):
+            self.network.step()
+        self._resetRecords()
+
+    def _resetRecords(self):
+        # Discard everything recorded during warmup so the recorded window
+        # begins at t=0 in steady state.
+        self.weightHistory = []
+        self.epochBoundaries = []
+        for pop in self.network.populations.values():
+            pop.rateRecord = []
+            pop.ablationInfluence = {}
+            for cell in pop.cells:
+                cell.rateRecord = []
+
+    def runEpoch(self, epoch):
+        start = self.epochDurationMs * (epoch - 1)
+        end = self.epochDurationMs * epoch
+        for _ in np.arange(start, end, self.tau):
+            self.network.step()
+            self._record_weight()
+        self.epochBoundaries.append(end)
+
+    def run(self):
+        raise NotImplementedError

--- a/rate/RateTwoColumnNetwork.py
+++ b/rate/RateTwoColumnNetwork.py
@@ -1,0 +1,124 @@
+from random import random, gauss
+
+from rate.RatePopulation import RatePopulation
+from rate.RateDiffuseReceptor import RateSomaticReceptorFactory, RateAxonalReceptorFactory
+
+'''
+Rate-model version of network/TwoColumnNetwork.py -- the paper's two-region
+sensory-loss architecture (regions alpha/A and beta/B, each with pyramidal P,
+fast-spiking F, and low-threshold-spiking L populations, plus a sensory input
+generator S). Structure mirrors the spiking TwoColumnNetwork and the methods
+draft's architecture figure:
+
+  S_A -> P_A (unimodal, axonal 5HT2A)         S_B -> P_B
+  S_A -> P_B (cross-modal)                    S_B -> P_A  (cross-modal; the
+                                                           remapping synapses)
+  P_r -> P_r (recurrent self + sparse all-to-all excitation)
+  P_r -> F_r -> P_r  (local E/I loop)
+  P_r -> L_r
+  L_A -> F_B, L_A -> P_B  (cross-modal inhibition)   L_B -> F_A, L_B -> P_A
+
+Somatic 5HT2A/5HT1A receptors sit on P and L cells; axonal 5HT2A receptors sit
+on the S->P input axons (modulating transmission). Weights are drawn per-synapse
+from a Gaussian with mean weight/popCount, exactly as in the spiking model.
+'''
+
+
+class RateTwoColumnNetwork:
+    def __init__(self, tau, params, name="RateTwoColumn"):
+        self.tau = tau
+        self.params = params
+        self.name = name
+        self.popCount = params["popCount"]
+        self.populations = {}
+
+        transmittersA = {"5HT2A": params["serotoninLevelA"], "5HT1A": params["serotoninLevelA"]}
+        transmittersB = {"5HT2A": params["serotoninLevelB"], "5HT1A": params["serotoninLevelB"]}
+
+        somaP = [RateSomaticReceptorFactory("5HT2A", params["Somatic5HT2AWeight"]),
+                 RateSomaticReceptorFactory("5HT1A", params["Somatic5HT1AWeight"])]
+        somaL = [RateSomaticReceptorFactory("5HT2A", params["Somatic5HT2AWeightLTS"]),
+                 RateSomaticReceptorFactory("5HT1A", params["Somatic5HT1AWeight"])]
+        axon5HT2A = [RateAxonalReceptorFactory("5HT2A", params["Axonal5HT2AWeight"])]
+
+        p = self.populations
+        # Input generators
+        p["InputA"] = RatePopulation(tau, None, self.popCount, [], {}, self, "InputA",
+                                     isInput=True, inputRate=params["rateA"])
+        p["InputB"] = RatePopulation(tau, None, self.popCount, [], {}, self, "InputB",
+                                     isInput=True, inputRate=params["rateB"])
+        # Region A
+        p["pyramidalsA"] = RatePopulation(tau, "Pyramidal", self.popCount, somaP, transmittersA, self, "pyramidalsA")
+        p["fastSpikingsA"] = RatePopulation(tau, "FS", self.popCount, [], transmittersA, self, "fastSpikingsA")
+        p["lowThresholdsA"] = RatePopulation(tau, "LTS", self.popCount, somaL, transmittersA, self, "lowThresholdsA")
+        # Region B
+        p["pyramidalsB"] = RatePopulation(tau, "Pyramidal", self.popCount, somaP, transmittersB, self, "pyramidalsB")
+        p["fastSpikingsB"] = RatePopulation(tau, "FS", self.popCount, [], transmittersB, self, "fastSpikingsB")
+        p["lowThresholdsB"] = RatePopulation(tau, "LTS", self.popCount, somaL, transmittersB, self, "lowThresholdsB")
+
+        gw = self._gaussWeightWithChance
+        sw = self._selfTargetingGaussWeight
+
+        # Unimodal input (axonal 5HT2A on these transmission axons)
+        p["InputA"].addOutboundConnections(p["pyramidalsA"], gw(params["inputWeightA"], 1.0), axon5HT2A)
+        p["InputB"].addOutboundConnections(p["pyramidalsB"], gw(params["inputWeightB"], 1.0), axon5HT2A)
+        # Cross-modal input (S_B -> P_A are the remapping synapses)
+        p["InputA"].addOutboundConnections(p["pyramidalsB"], gw(params["inputWeightAB"], params["crossModalABLikelihood"]), axon5HT2A)
+        p["InputB"].addOutboundConnections(p["pyramidalsA"], gw(params["inputWeightBA"], params["crossModalBALikelihood"]), axon5HT2A)
+
+        # Pyramidal recurrent excitation (self 1:1 + sparse all-to-all)
+        for region in ("A", "B"):
+            p["pyramidals" + region].addOutboundConnections(p["pyramidals" + region], sw(params["pyramidalSelfExcitationWeight"]))
+            p["pyramidals" + region].addOutboundConnections(p["pyramidals" + region], gw(params["pyramidalToPyramidalWeight"], params["pyramidalToPyramidalLikelihood"]))
+            # Local E/I loop
+            p["pyramidals" + region].addOutboundConnections(p["fastSpikings" + region], gw(params["PyramidalsToFSWeight"], 1.0))
+            p["fastSpikings" + region].addOutboundConnections(p["pyramidals" + region], gw(params["FSToPyramidalsWeight"], 1.0))
+            p["pyramidals" + region].addOutboundConnections(p["lowThresholds" + region], gw(params["PyramidalsToLTSWeight"], 1.0))
+
+        # Cross-modal inhibition from LTS
+        p["lowThresholdsA"].addOutboundConnections(p["fastSpikingsB"], gw(params["LTStoFSWeight"], 1.0))
+        p["lowThresholdsA"].addOutboundConnections(p["pyramidalsB"], gw(params["LTStoPyramidalsWeight"], 1.0))
+        p["lowThresholdsB"].addOutboundConnections(p["fastSpikingsA"], gw(params["LTStoFSWeight"], 1.0))
+        p["lowThresholdsB"].addOutboundConnections(p["pyramidalsA"], gw(params["LTStoPyramidalsWeight"], 1.0))
+
+    # ---- weight function factories (same math as the spiking model) ----
+
+    def _gaussWeightWithChance(self, inputWeight, chance):
+        popCount = self.popCount
+        def weightFunction(source, target):
+            if random() < chance:
+                return gauss(inputWeight / popCount, abs(inputWeight / popCount) / 10)
+            return None
+        return weightFunction
+
+    def _selfTargetingGaussWeight(self, inputWeight):
+        popCount = self.popCount
+        def weightFunction(source, target):
+            if source is target:
+                return gauss(inputWeight / popCount, abs(inputWeight / popCount) / 10)
+            return None
+        return weightFunction
+
+    # ---- serotonin control ----
+
+    def setSerotoninA(self, level):
+        self._setRegionSerotonin("A", level)
+
+    def setSerotoninB(self, level):
+        self._setRegionSerotonin("B", level)
+
+    def _setRegionSerotonin(self, region, level):
+        transmitters = {"5HT2A": level, "5HT1A": level}
+        for key in ("pyramidals" + region, "fastSpikings" + region, "lowThresholds" + region):
+            self.populations[key].setDiffuseTransmitters(transmitters)
+
+    # ---- remapping synapses (S_B -> P_A) ----
+
+    def remappingAxons(self):
+        return self.populations["InputB"].outboundAxonsTo(self.populations["pyramidalsA"])
+
+    def step(self):
+        for population in self.populations.values():
+            population.stepCells()
+        for population in self.populations.values():
+            population.stepOutputs()

--- a/rate/RateTwoColumnNetwork.py
+++ b/rate/RateTwoColumnNetwork.py
@@ -108,9 +108,16 @@ class RateTwoColumnNetwork:
         self._setRegionSerotonin("B", level)
 
     def _setRegionSerotonin(self, region, level):
-        transmitters = {"5HT2A": level, "5HT1A": level}
+        # Uniform serotonin: both 5HT2A and 5HT1A set to the same level.
+        self.setRegionTransmitters(region, {"5HT2A": level, "5HT1A": level})
+
+    def setRegionTransmitters(self, region, transmitters):
+        # Set arbitrary per-receptor-type diffuse levels for a region, e.g.
+        # {"5HT2A": 40, "5HT1A": 10} to raise only 5HT2A (pharmacological /
+        # 5HT2A-agonist manipulation). Updates somatic receptors on the region's
+        # cells and axonal receptors on its inbound axons.
         for key in ("pyramidals" + region, "fastSpikings" + region, "lowThresholds" + region):
-            self.populations[key].setDiffuseTransmitters(transmitters)
+            self.populations[key].setDiffuseTransmitters(dict(transmitters))
 
     # ---- remapping synapses (S_B -> P_A) ----
 

--- a/rate/RateTwoColumnParams.py
+++ b/rate/RateTwoColumnParams.py
@@ -9,6 +9,7 @@ def buildDefaultParams():
     params = {}
     params["tau"] = 0.1
     params["epochDurationMs"] = 1000     # paper figures use 1000 ms epochs
+    params["warmupMs"] = 500             # settle to steady state before epoch 1
     params["popCount"] = 20
 
     # Input drive (Poisson lambda, Hz). Draft baseline lambda = 30.

--- a/rate/RateTwoColumnParams.py
+++ b/rate/RateTwoColumnParams.py
@@ -23,7 +23,7 @@ def buildDefaultParams():
     # Somatic serotonin receptor weights (per unit serotonin level). Code-sign
     # convention: 5HT2A depolarizing (+), 5HT1A hyperpolarizing (-); |2A|>|1A|
     # so raising serotonin in epoch 3 nets depolarizing drive.
-    params["Somatic5HT2AWeight"] = 2.0
+    params["Somatic5HT2AWeight"] = 5.0
     params["Somatic5HT1AWeight"] = -1.0
     params["Somatic5HT2AWeightLTS"] = 3.0
 
@@ -32,11 +32,11 @@ def buildDefaultParams():
     params["Axonal5HT2AWeight"] = 0.005
 
     # Feedforward input weights (pooled; divided by popCount per synapse).
-    params["inputWeightA"] = 400.0
-    params["inputWeightB"] = 400.0
-    params["inputWeightAB"] = 200.0
+    params["inputWeightA"] = 500.0
+    params["inputWeightB"] = 500.0
+    params["inputWeightAB"] = 300.0
     params["crossModalABLikelihood"] = 0.5
-    params["inputWeightBA"] = 200.0      # S_B -> P_A: the remapping synapses
+    params["inputWeightBA"] = 300.0      # S_B -> P_A: the remapping synapses
     params["crossModalBALikelihood"] = 0.5
 
     # Recurrent / local circuit
@@ -52,8 +52,12 @@ def buildDefaultParams():
     # Plasticity (Graupner/Brunel calcium rule), inflated per the draft for the
     # short epoch. Tuned so the remapping synapses potentiate meaningfully in
     # epoch 3 without diverging.
-    params["gamma_p"] = 1e-4
-    params["gamma_d"] = 1e-3
-    params["plasticityThreshold"] = 50.0
+    params["gamma_p"] = 50.0
+    params["gamma_d"] = 5e-4
+    params["plasticityThreshold"] = 3.0
+    # Soft weight ceiling: remapping synapses may potentiate up to this multiple
+    # of their initial weight, past which LTP smoothly saturates (keeps the
+    # calcium-driven rule stable). See RateAxon._applyPlasticity.
+    params["plasticityCeilingFactor"] = 4.0
 
     return params

--- a/rate/RateTwoColumnParams.py
+++ b/rate/RateTwoColumnParams.py
@@ -1,0 +1,59 @@
+def buildDefaultParams():
+    """Starting parameters for the rate two-region sensory-loss model.
+
+    Weights are on the rate model's current scale (chosen so pyramidal cells sit
+    at biologically sane tens-of-Hz rates), NOT the spiking model's inflated
+    scale. These are a tuning starting point; see rate/README for the validation
+    targets they are being tuned against.
+    """
+    params = {}
+    params["tau"] = 0.1
+    params["epochDurationMs"] = 1000     # paper figures use 1000 ms epochs
+    params["popCount"] = 20
+
+    # Input drive (Poisson lambda, Hz). Draft baseline lambda = 30.
+    params["rateA"] = 30.0
+    params["rateB"] = 30.0
+
+    # Diffuse serotonin levels and the epoch-3 elevation (draft: 10 -> 40 in A).
+    params["serotoninLevelA"] = 10.0
+    params["serotoninLevelB"] = 10.0
+    params["remapSerotoninLevel"] = 40.0
+
+    # Somatic serotonin receptor weights (per unit serotonin level). Code-sign
+    # convention: 5HT2A depolarizing (+), 5HT1A hyperpolarizing (-); |2A|>|1A|
+    # so raising serotonin in epoch 3 nets depolarizing drive.
+    params["Somatic5HT2AWeight"] = 2.0
+    params["Somatic5HT1AWeight"] = -1.0
+    params["Somatic5HT2AWeightLTS"] = 3.0
+
+    # Axonal 5HT2A on S->P input axons. 0.005 with base failure 0.25 gives the
+    # draft's 20% failure at serotonin 10 and 5% at serotonin 40.
+    params["Axonal5HT2AWeight"] = 0.005
+
+    # Feedforward input weights (pooled; divided by popCount per synapse).
+    params["inputWeightA"] = 400.0
+    params["inputWeightB"] = 400.0
+    params["inputWeightAB"] = 200.0
+    params["crossModalABLikelihood"] = 0.5
+    params["inputWeightBA"] = 200.0      # S_B -> P_A: the remapping synapses
+    params["crossModalBALikelihood"] = 0.5
+
+    # Recurrent / local circuit
+    params["pyramidalSelfExcitationWeight"] = 60.0
+    params["pyramidalToPyramidalWeight"] = 60.0
+    params["pyramidalToPyramidalLikelihood"] = 0.3
+    params["PyramidalsToFSWeight"] = 400.0
+    params["FSToPyramidalsWeight"] = -400.0
+    params["PyramidalsToLTSWeight"] = 250.0
+    params["LTStoFSWeight"] = -150.0
+    params["LTStoPyramidalsWeight"] = -150.0
+
+    # Plasticity (Graupner/Brunel calcium rule), inflated per the draft for the
+    # short epoch. Tuned so the remapping synapses potentiate meaningfully in
+    # epoch 3 without diverging.
+    params["gamma_p"] = 1e-4
+    params["gamma_d"] = 1e-3
+    params["plasticityThreshold"] = 50.0
+
+    return params

--- a/rate/RateTwoColumnParams.py
+++ b/rate/RateTwoColumnParams.py
@@ -61,4 +61,13 @@ def buildDefaultParams():
     # calcium-driven rule stable). See RateAxon._applyPlasticity.
     params["plasticityCeilingFactor"] = 4.0
 
+    # Pharmacological (5HT2A-agonist / psilocybin) experiment. No sensory loss;
+    # in epoch 2 only 5HT2A is raised (to pharma5HT2ALevel) in BOTH regions,
+    # 5HT1A stays at baseline, and plasticity runs an order of magnitude weaker
+    # than the sensory experiment (reflecting the far shorter modeled timescale,
+    # per the methods draft).
+    params["pharma5HT2ALevel"] = 40.0
+    params["pharma_gamma_p"] = params["gamma_p"] * 0.1
+    params["pharma_gamma_d"] = params["gamma_d"] * 0.1
+
     return params

--- a/rate/RateTwoColumnSimulation.py
+++ b/rate/RateTwoColumnSimulation.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-from rate.RateTwoColumnNetwork import RateTwoColumnNetwork
+from rate.RateSimulationBase import RateSimulationBase
 
 '''
 Four-epoch sensory-loss simulation on the rate two-region network, mirroring
@@ -21,53 +19,7 @@ were an artifact of the 2003/2007 integration mismatch).
 '''
 
 
-class RateTwoColumnSimulation:
-    def __init__(self, params):
-        self.params = params
-        self.tau = params["tau"]
-        self.epochDurationMs = params["epochDurationMs"]
-        # Settling period run at baseline before epoch 1, so the recorded epochs
-        # start from the network's steady state rather than from rest. Without
-        # it, the influence/rate traces show a startup overshoot in epoch 1 (the
-        # network ramping up from zero and settling) that reads as ipsimodal
-        # influence "declining" during baseline before it flattens out.
-        self.warmupMs = params.get("warmupMs", 500.0)
-        self.network = RateTwoColumnNetwork(self.tau, params)
-        self.remapping = self.network.remappingAxons()
-
-        # Recorded time series (mean weight of remapping synapses per step).
-        self.weightHistory = []
-        self.epochBoundaries = []
-        self.weightsByEpoch = {}
-
-    def _record_weight(self):
-        if self.remapping:
-            self.weightHistory.append(float(np.mean([a.weight for a in self.remapping])))
-
-    def warmup(self):
-        for _ in np.arange(0.0, self.warmupMs, self.tau):
-            self.network.step()
-        self._resetRecords()
-
-    def _resetRecords(self):
-        # Discard everything recorded during warmup so the recorded window
-        # begins at t=0 in steady state.
-        self.weightHistory = []
-        self.epochBoundaries = []
-        for pop in self.network.populations.values():
-            pop.rateRecord = []
-            pop.ablationInfluence = {}
-            for cell in pop.cells:
-                cell.rateRecord = []
-
-    def runEpoch(self, epoch):
-        start = self.epochDurationMs * (epoch - 1)
-        end = self.epochDurationMs * epoch
-        for _ in np.arange(start, end, self.tau):
-            self.network.step()
-            self._record_weight()
-        self.epochBoundaries.append(end)
-
+class RateTwoColumnSimulation(RateSimulationBase):
     def epoch1(self):
         self.runEpoch(1)
         self.weightsByEpoch["1_baseline"] = [a.weight for a in self.remapping]

--- a/rate/RateTwoColumnSimulation.py
+++ b/rate/RateTwoColumnSimulation.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+from rate.RateTwoColumnNetwork import RateTwoColumnNetwork
+
+'''
+Four-epoch sensory-loss simulation on the rate two-region network, mirroring
+network/TwoColumnSimulation.py and the methods draft's Input section:
+
+  epoch 1  baseline: both inputs on, serotonin at baseline
+  epoch 2  sensory loss: Input A rate -> 0 (stays 0 for the rest)
+  epoch 3  serotonin + plasticity: serotonin in region A raised, and plasticity
+           switched on for the cross-modal remapping synapses (S_B -> P_A) with
+           the (inflated, per the draft) plasticity constants
+  epoch 4  return: serotonin in A back to baseline, plasticity off
+
+The rate model produces biologically sane firing rates (tens-hundreds of Hz),
+so the validation target is the qualitative epoch structure and the
+persistence of the cross-modal influence shift into epoch 4 -- the paper's
+actual claims -- not the inflated absolute rates in the spiking figures (which
+were an artifact of the 2003/2007 integration mismatch).
+'''
+
+
+class RateTwoColumnSimulation:
+    def __init__(self, params):
+        self.params = params
+        self.tau = params["tau"]
+        self.epochDurationMs = params["epochDurationMs"]
+        self.network = RateTwoColumnNetwork(self.tau, params)
+        self.remapping = self.network.remappingAxons()
+
+        # Recorded time series (mean weight of remapping synapses per step).
+        self.weightHistory = []
+        self.epochBoundaries = []
+        self.weightsByEpoch = {}
+
+    def _record_weight(self):
+        if self.remapping:
+            self.weightHistory.append(float(np.mean([a.weight for a in self.remapping])))
+
+    def runEpoch(self, epoch):
+        start = self.epochDurationMs * (epoch - 1)
+        end = self.epochDurationMs * epoch
+        for _ in np.arange(start, end, self.tau):
+            self.network.step()
+            self._record_weight()
+        self.epochBoundaries.append(end)
+
+    def epoch1(self):
+        self.runEpoch(1)
+        self.weightsByEpoch["1_baseline"] = [a.weight for a in self.remapping]
+
+    def epoch2(self):
+        self.network.populations["InputA"].setRate(0.0)
+        self.runEpoch(2)
+        self.weightsByEpoch["2_sensory_loss"] = [a.weight for a in self.remapping]
+
+    def epoch3(self):
+        self.network.setSerotoninA(self.params["remapSerotoninLevel"])
+        for axon in self.remapping:
+            axon.enablePlasticity(self.params["gamma_p"], self.params["gamma_d"], self.params["plasticityThreshold"])
+        self.runEpoch(3)
+        for axon in self.remapping:
+            axon.disablePlasticity()
+        self.weightsByEpoch["3_serotonin_plasticity"] = [a.weight for a in self.remapping]
+
+    def epoch4(self):
+        self.network.setSerotoninA(self.params["serotoninLevelA"])
+        self.runEpoch(4)
+        self.weightsByEpoch["4_return"] = [a.weight for a in self.remapping]
+
+    def run(self):
+        self.epoch1()
+        self.epoch2()
+        self.epoch3()
+        self.epoch4()

--- a/rate/RateTwoColumnSimulation.py
+++ b/rate/RateTwoColumnSimulation.py
@@ -58,7 +58,9 @@ class RateTwoColumnSimulation:
     def epoch3(self):
         self.network.setSerotoninA(self.params["remapSerotoninLevel"])
         for axon in self.remapping:
-            axon.enablePlasticity(self.params["gamma_p"], self.params["gamma_d"], self.params["plasticityThreshold"])
+            axon.enablePlasticity(self.params["gamma_p"], self.params["gamma_d"],
+                                  self.params["plasticityThreshold"],
+                                  ceilingFactor=self.params["plasticityCeilingFactor"])
         self.runEpoch(3)
         for axon in self.remapping:
             axon.disablePlasticity()

--- a/rate/RateTwoColumnSimulation.py
+++ b/rate/RateTwoColumnSimulation.py
@@ -26,6 +26,12 @@ class RateTwoColumnSimulation:
         self.params = params
         self.tau = params["tau"]
         self.epochDurationMs = params["epochDurationMs"]
+        # Settling period run at baseline before epoch 1, so the recorded epochs
+        # start from the network's steady state rather than from rest. Without
+        # it, the influence/rate traces show a startup overshoot in epoch 1 (the
+        # network ramping up from zero and settling) that reads as ipsimodal
+        # influence "declining" during baseline before it flattens out.
+        self.warmupMs = params.get("warmupMs", 500.0)
         self.network = RateTwoColumnNetwork(self.tau, params)
         self.remapping = self.network.remappingAxons()
 
@@ -37,6 +43,22 @@ class RateTwoColumnSimulation:
     def _record_weight(self):
         if self.remapping:
             self.weightHistory.append(float(np.mean([a.weight for a in self.remapping])))
+
+    def warmup(self):
+        for _ in np.arange(0.0, self.warmupMs, self.tau):
+            self.network.step()
+        self._resetRecords()
+
+    def _resetRecords(self):
+        # Discard everything recorded during warmup so the recorded window
+        # begins at t=0 in steady state.
+        self.weightHistory = []
+        self.epochBoundaries = []
+        for pop in self.network.populations.values():
+            pop.rateRecord = []
+            pop.ablationInfluence = {}
+            for cell in pop.cells:
+                cell.rateRecord = []
 
     def runEpoch(self, epoch):
         start = self.epochDurationMs * (epoch - 1)
@@ -72,6 +94,7 @@ class RateTwoColumnSimulation:
         self.weightsByEpoch["4_return"] = [a.weight for a in self.remapping]
 
     def run(self):
+        self.warmup()
         self.epoch1()
         self.epoch2()
         self.epoch3()

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -333,6 +333,20 @@ class RetinotopicGrandPlanNetwork:
             for receptor in cell.diffuseReceptors:
                 receptor.setLevel(float(level))
 
+    def setDeprivedIntrinsicDrive(self, offset, cells=None):
+        # Deprivation-induced intrinsic-excitability homeostasis (Desai, Rutherford
+        # & Turrigiano 1999): an input-INDEPENDENT tonic depolarization of the
+        # deprived region. Unlike bottom-up gain (which amplifies an absent input)
+        # or disinhibition (which removes an absent, activity-driven inhibition),
+        # this can raise firing in a cortex that has lost its feedforward drive --
+        # the source of the transient hyperactivity that provides the postsynaptic
+        # activity Hebbian cross-modal remapping needs to bootstrap. Applied via
+        # the neuron's external (injected) current, which is additive outside the
+        # normalized mixture.
+        cells = self.populations["V1pyr"].cells if cells is None else cells
+        for cell in cells:
+            cell.setInjectedCurrent(float(offset))
+
     def setCrossModalAxonalSerotonin(self, level, axons=None):
         # Set the axonal 5HT receptor level on the cross-modal AudioInput -> V1
         # remapping axons (all, or a subset), raising transmission (lowering

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -472,6 +472,10 @@ class RetinotopicGrandPlanNetwork:
         for pop in self.populations.values():
             for cell in pop.cells:
                 cell.recordCellHistory = bool(enabled)
+                if not enabled:
+                    # Free anything already accumulated (e.g. during ART
+                    # pretraining) so it does not linger for the whole run.
+                    cell.rateRecord = []
 
     def resetActivity(self):
         # Zero all firing rates, conductances, and synaptic accumulators, for a

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -1,9 +1,12 @@
 from random import random, gauss
 
+import numpy as np
+
 from rate.RatePopulation import RatePopulation
 from rate.NormalizedMixtureNeuron import (
     NormalizedMixtureNeuron, STREAM_BOTTOMUP, STREAM_TOPDOWN, STREAM_SELF)
 from rate.RateDiffuseReceptor import RateSomaticReceptorFactory, RateAxonalReceptorFactory
+from rate.ARTClassifier import REJECT
 
 '''
 Retinotopic grand-plan architecture (rate-based), with the primary visual area
@@ -64,6 +67,20 @@ class RetinotopicGrandPlanNetwork:
         self.categoryCount = params["categoryCount"]
         self.populations = {}
 
+        # Secondary area: either the first-pass competitive Category layer, or
+        # (useART) a Fuzzy ART classifier that reads the V1 map and drives a
+        # per-column TopDown input population with the winning category's
+        # template (content-specific feedback; zero on reject).
+        self.useART = bool(params.get("useART", False))
+        self.art = None
+        self.artActive = False
+        # V1 column rate (Hz) that maps to feature value 1.0 when normalizing the
+        # V1 map into the ART [0,1] feature space; and the Hz the top-down
+        # template's value 1.0 projects back as.
+        self.artReferenceRate = float(params.get("artReferenceRate", 6.0))
+        self.topDownDriveHz = float(params.get("topDownDriveHz", params["maxRateHz"]))
+        self.lastART = {"label": None, "reject": True, "match": 0.0, "category": None}
+
         transmitters = {"5HT2A": params["serotoninLevel"], "5HT1A": params["serotoninLevel"]}
         somaP = [RateSomaticReceptorFactory("5HT2A", params["Somatic5HT2AWeight"]),
                  RateSomaticReceptorFactory("5HT1A", params["Somatic5HT1AWeight"])]
@@ -95,9 +112,15 @@ class RetinotopicGrandPlanNetwork:
         # current, so we do not report that metric for V1 (see NormalizedMixtureNeuron).
         p["V1pyr"].trackInfluence = False
 
-        # ---- secondary area: competitive classifier ----
-        p["Category"] = RatePopulation(tau, "Pyramidal", self.categoryCount,
-                                       somaP, transmitters, self, "Category")
+        # ---- secondary area ----
+        if self.useART:
+            # Per-column top-down input population driven by the ART classifier.
+            p["TopDown"] = RatePopulation(tau, None, self.nCols, [], {}, self, "TopDown",
+                                          isInput=True, inputRate=0.0)
+        else:
+            # First-pass competitive classifier.
+            p["Category"] = RatePopulation(tau, "Pyramidal", self.categoryCount,
+                                           somaP, transmitters, self, "Category")
 
         # Cache each cell's index within its population so the connectivity weight
         # functions are O(1) rather than O(n) (cells.index) inside the O(n^2) build.
@@ -179,44 +202,59 @@ class RetinotopicGrandPlanNetwork:
             return None
         p["V1fs"].addOutboundConnections(p["V1pyr"], fsToV1)
 
-        # Feedforward pooling into the secondary area: all V1pyr -> each Category
-        # cell (the classifier reads the whole V1 map). Templates (per-category
-        # selectivity) live in the weight sign/magnitude; here a mild positive
-        # pooling weight, refined by template assignment in setCategoryTemplates.
-        def v1ToCategory(source, target):
-            w = params["v1ToCategoryWeight"] / (self.nCols * cpc)
-            return gauss(w, abs(w) / 10)
-        p["V1pyr"].addOutboundConnections(p["Category"], v1ToCategory)
-
-        # Lateral competition among Category cells (winner-take-all via mutual
-        # inhibition): each category inhibits the others.
-        def categoryCompetition(source, target):
-            if source is not target:
-                w = params["categoryInhibitionWeight"]
+        if self.useART:
+            # Top-down feedback: TopDown column c -> V1pyr cells in column c.
+            # The ART classifier sets TopDown column rates each step to the
+            # winning category's template (retinotopic, content-specific).
+            def topDownToV1(source, target):
+                if source._idx == self._colOf(target._idx, cpc):
+                    w = params["categoryToV1Weight"] / cpc
+                    return gauss(w, abs(w) / 10)
+                return None
+            p["TopDown"].addOutboundConnections(p["V1pyr"], topDownToV1)
+        else:
+            # Feedforward pooling into the secondary area: all V1pyr -> each
+            # Category cell (the classifier reads the whole V1 map).
+            def v1ToCategory(source, target):
+                w = params["v1ToCategoryWeight"] / (self.nCols * cpc)
                 return gauss(w, abs(w) / 10)
-            return None
-        p["Category"].addOutboundConnections(p["Category"], categoryCompetition)
+            p["V1pyr"].addOutboundConnections(p["Category"], v1ToCategory)
 
-        # Top-down feedback: Category -> V1pyr. The winning category projects its
-        # template back onto V1 as the top-down stream.
-        def categoryToV1(source, target):
-            w = params["categoryToV1Weight"] / self.categoryCount
-            return gauss(w, abs(w) / 10)
-        p["Category"].addOutboundConnections(p["V1pyr"], categoryToV1)
+            # Lateral competition among Category cells (winner-take-all).
+            def categoryCompetition(source, target):
+                if source is not target:
+                    w = params["categoryInhibitionWeight"]
+                    return gauss(w, abs(w) / 10)
+                return None
+            p["Category"].addOutboundConnections(p["Category"], categoryCompetition)
+
+            # Top-down feedback: Category -> V1pyr.
+            def categoryToV1(source, target):
+                w = params["categoryToV1Weight"] / self.categoryCount
+                return gauss(w, abs(w) / 10)
+            p["Category"].addOutboundConnections(p["V1pyr"], categoryToV1)
 
     def _assignV1Streams(self):
         # Tag each V1 pyramidal's inbound source populations into Sulfaro streams.
         p = self.populations
+        topDownPop = p["TopDown"] if self.useART else p["Category"]
         streamByPop = {
             p["VisualInput"]: STREAM_BOTTOMUP,
             p["AudioInput"]: STREAM_BOTTOMUP,   # cross-modal ascending drive
             p["V1pyr"]: STREAM_SELF,            # recurrent excitation
             p["V1fs"]: STREAM_SELF,             # local inhibition (current-layer)
-            p["Category"]: STREAM_TOPDOWN,      # descending feedback
+            topDownPop: STREAM_TOPDOWN,         # descending feedback
         }
         for cell in p["V1pyr"].cells:
             for srcPop, stream in streamByPop.items():
                 cell.assignStream(srcPop, stream)
+
+    def _serotoninTargets(self):
+        # Populations carrying somatic serotonin receptors (exclude input pops).
+        keys = ["V1pyr", "V1fs"]
+        if not self.useART:
+            keys.append("Category")
+        return keys
 
     # ---- runtime controls ----
 
@@ -240,14 +278,14 @@ class RetinotopicGrandPlanNetwork:
 
     def setSerotonin(self, level):
         transmitters = {"5HT2A": level, "5HT1A": level}
-        for key in ("V1pyr", "V1fs", "Category"):
+        for key in self._serotoninTargets():
             self.populations[key].setDiffuseTransmitters(dict(transmitters))
 
     def set5HT2A(self, level):
         # Raise only 5HT2A (pharmacological / agonist), 5HT1A at baseline.
         base = self.params["serotoninLevel"]
         transmitters = {"5HT2A": level, "5HT1A": base}
-        for key in ("V1pyr", "V1fs", "Category"):
+        for key in self._serotoninTargets():
             self.populations[key].setDiffuseTransmitters(dict(transmitters))
 
     def setV1BottomUpGain(self, gain):
@@ -260,8 +298,88 @@ class RetinotopicGrandPlanNetwork:
         # The cross-modal AudioInput -> V1pyr synapses (analogue of S_B -> P_A).
         return self.populations["AudioInput"].outboundAxonsTo(self.populations["V1pyr"])
 
+    # ---- ART secondary area ----
+
+    def v1ColumnRates(self):
+        # Per-column mean V1 pyramidal rate (Hz), length nCols.
+        cpc = self.cellsPerColumn
+        cells = self.populations["V1pyr"].cells
+        return np.array([np.mean([cells[c * cpc + k].rate for k in range(cpc)])
+                         for c in range(self.nCols)])
+
+    def v1FeatureVector(self):
+        # Normalize the V1 column-rate map into the ART [0,1] feature space by a
+        # FIXED reference rate (not a per-pattern max), so overall activity level
+        # is meaningful: a globally suppressed (deprived) map yields low feature
+        # values -> rejected by the ART activity gate, while a serotonin-inflated
+        # map yields high values -> can be classified (a hallucination readout).
+        return np.clip(self.v1ColumnRates() / self.artReferenceRate, 0.0, 1.0)
+
+    def attachART(self, art):
+        self.art = art
+
+    def setARTActive(self, active):
+        # When active, ART reads V1 and drives TopDown each step. Kept off during
+        # classifier pre-training so V1 is purely bottom-up driven.
+        self.artActive = bool(active)
+        if not active:
+            for cell in self.populations["TopDown"].cells:
+                cell.setRate(0.0)
+
+    def updateTopDownFromART(self):
+        # ART reads the current V1 feature, classifies, and drives the TopDown
+        # population with the winning category's template (0 on reject).
+        x = self.v1FeatureVector()
+        label, (cat, match) = self.art.classify(x, return_detail=True)
+        reject = (label == REJECT) or (cat is None)
+        if reject:
+            template = np.zeros(self.nCols)
+        else:
+            template = self.art.category_template(cat)   # [0,1]^nCols
+        rates = template * self.topDownDriveHz
+        for cell, r in zip(self.populations["TopDown"].cells, rates):
+            cell.setRate(float(r))
+        self.lastART = {"label": None if reject else label,
+                        "reject": bool(reject), "match": float(match), "category": cat}
+
+    def resetActivity(self):
+        # Zero all firing rates, conductances, and synaptic accumulators, for a
+        # clean presentation (used between ART training images).
+        for pop in self.populations.values():
+            for cell in pop.cells:
+                cell.rate = 0.0
+                if hasattr(cell, "clearSynapticAccumulators"):
+                    cell.clearSynapticAccumulators()
+            for axon in pop.outboundAxons:
+                axon.g_ampa = axon.g_nmda = axon.g_gaba = 0.0
+
     def step(self):
+        if self.useART and self.art is not None and self.artActive:
+            self.updateTopDownFromART()
         for population in self.populations.values():
             population.stepCells()
         for population in self.populations.values():
             population.stepOutputs()
+
+
+def pretrainART(network, inputSet, art, settleMs):
+    """Train the ART classifier on the V1 representations of the labeled stimuli.
+
+    Each stimulus is presented (top-down inactive, so V1 is purely bottom-up
+    driven), V1 is settled for settleMs, and ART learns (V1 feature -> label).
+    The classifier is thus trained on the actual V1 activity patterns it will
+    later classify, not on the raw edge images. Attaches the trained ART to the
+    network but leaves it inactive; the caller enables it with setARTActive(True).
+    """
+    tau = network.tau
+    network.setARTActive(False)
+    steps = int(round(settleMs / tau))
+    for st in inputSet.stimuli:
+        network.resetActivity()
+        network.setVisualRates(inputSet.visualRates(st))
+        network.setAudioRates(inputSet.audioRates(st))
+        for _ in range(steps):
+            network.step()
+        art.train_one(network.v1FeatureVector(), st.label)
+    network.attachART(art)
+    return art

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -280,6 +280,7 @@ class RetinotopicGrandPlanNetwork:
         transmitters = {"5HT2A": level, "5HT1A": level}
         for key in self._serotoninTargets():
             self.populations[key].setDiffuseTransmitters(dict(transmitters))
+        self._updateMixtureFromSerotonin(level)
 
     def set5HT2A(self, level):
         # Raise only 5HT2A (pharmacological / agonist), 5HT1A at baseline.
@@ -287,10 +288,34 @@ class RetinotopicGrandPlanNetwork:
         transmitters = {"5HT2A": level, "5HT1A": base}
         for key in self._serotoninTargets():
             self.populations[key].setDiffuseTransmitters(dict(transmitters))
+        self._updateMixtureFromSerotonin(level)
+
+    def _updateMixtureFromSerotonin(self, level5ht2a):
+        # Sulfaro / Seillier-Michaiel neurochemical bridge: 5HT2A dampens V1's
+        # bottom-up gain, i.e. lowers the ascending stream weight in the
+        # normalized mixture (shifting the feedforward:feedback ratio toward
+        # feedback). This SUPPLEMENTS the somatic (additive) and axonal
+        # (transmission) serotonin effects; it is the only one that actually
+        # moves the Sulfaro competition. Opt-in via serotoninShiftsMixture.
+        #
+        #   bottomUpGain(L) = clamp(1 - damp * (L - baseline)/baseline, floor, 1)
+        #
+        # so gain = 1 at baseline serotonin and falls toward `floor` as 5HT2A
+        # rises. Note this partly opposes the axonal 5HT2A effect (which raises
+        # bottom-up *transmission*); they act on different quantities (stream
+        # weight vs axon efficacy) and coexist, as documented.
+        if not self.params.get("serotoninShiftsMixture", False):
+            return
+        base = self.params["serotoninLevel"]
+        damp = self.params.get("bottomUpGainDamp", 0.2)
+        floor = self.params.get("minBottomUpGain", 0.1)
+        gain = 1.0 - damp * max(0.0, (level5ht2a - base) / base)
+        gain = max(floor, min(1.0, gain))
+        self.setV1BottomUpGain(gain)
 
     def setV1BottomUpGain(self, gain):
-        # Sulfaro neurochemical bridge: scale the bottom-up stream weight on every
-        # V1 pyramidal (5HT2A dampening of bottom-up gain -> gain < 1).
+        # Scale the bottom-up stream weight on every V1 pyramidal. Called by the
+        # serotonin coupling above, and directly by analyses that sweep the gain.
         for cell in self.populations["V1pyr"].cells:
             cell.bottomUpGain = float(gain)
 

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -463,6 +463,16 @@ class RetinotopicGrandPlanNetwork:
         self.artActive = wasActive
         return percept
 
+    def setCellHistoryRecording(self, enabled):
+        # Turn per-cell rateRecord accumulation on/off across every population.
+        # Off keeps long (10x10, hundreds of thousands of steps) runs within the
+        # memory budget: the per-cell history is the dominant cost (~7 GB) and is
+        # unused by the grand-plan metrics/plots (population-level rateRecord and
+        # the recorded scalar series are untouched).
+        for pop in self.populations.values():
+            for cell in pop.cells:
+                cell.recordCellHistory = bool(enabled)
+
     def resetActivity(self):
         # Zero all firing rates, conductances, and synaptic accumulators, for a
         # clean presentation (used between ART training images).

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -342,6 +342,64 @@ class RetinotopicGrandPlanNetwork:
         self.lastART = {"label": None if reject else label,
                         "reject": bool(reject), "match": float(match), "category": cat}
 
+    def renderTopDownPercept(self, template, settleMs, gain=1.0,
+                             disconnectBottomUp=True):
+        """Drive V1 with ONLY a top-down template and return the settled V1
+        column-rate map -- the percept that top-down feedback alone paints on V1.
+
+        template : per-column [0,1] pattern (e.g. an ART category template, from
+                   art.category_template(j)).
+        gain     : multiplies the top-down SYNAPTIC WEIGHT (a linear current
+                   boost) to show the hallucination under stronger-than-observed
+                   feedback influence. Note gain is applied to the weight, not the
+                   TopDown firing rate, because the synaptic conductance saturates
+                   in rate so rate scaling has little effect above ~30 Hz.
+        disconnectBottomUp : silence the visual+audio inputs AND remove the
+                   bottom-up stream from the V1 mixture (weight -> 0). This is
+                   Sulfaro's "sensory disconnection" scenario: with ascending
+                   input downweighted to zero, the normalized mixture renders the
+                   pure top-down (imagined/hallucinated) percept, undiluted by the
+                   empty bottom-up slot in the denominator.
+
+        All modified state (ART-active flag, input rates, bottom-up stream
+        weights, top-down axon weights) is restored before returning.
+        """
+        template = np.asarray(template, dtype=float)
+        wasActive = self.artActive
+        self.resetActivity()
+        self.setARTActive(False)   # hold TopDown fixed; also zeros it, so set AFTER
+
+        v1 = self.populations["V1pyr"].cells
+        saved_wbu = [c.streamWeights[STREAM_BOTTOMUP] for c in v1]
+        if disconnectBottomUp:
+            for cell in self.populations["VisualInput"].cells:
+                cell.setRate(0.0)
+            for cell in self.populations["AudioInput"].cells:
+                cell.setRate(0.0)
+            for c in v1:
+                c.streamWeights[STREAM_BOTTOMUP] = 0.0
+
+        tdAxons = self.populations["TopDown"].outboundAxons
+        saved_w = [a.weight for a in tdAxons]
+        for a in tdAxons:
+            a.weight *= gain
+            a._recomputeEffWeight()
+
+        rates = np.clip(template * self.topDownDriveHz, 0.0, None)
+        for cell, r in zip(self.populations["TopDown"].cells, rates):
+            cell.setRate(float(r))
+        for _ in range(int(round(settleMs / self.tau))):
+            self.step()               # artActive is False, so TopDown stays clamped
+        percept = self.v1ColumnRates().reshape(self.G, self.G)
+
+        # restore
+        for a, w in zip(tdAxons, saved_w):
+            a.weight = w; a._recomputeEffWeight()
+        for c, w in zip(v1, saved_wbu):
+            c.streamWeights[STREAM_BOTTOMUP] = w
+        self.artActive = wasActive
+        return percept
+
     def resetActivity(self):
         # Zero all firing rates, conductances, and synaptic accumulators, for a
         # clean presentation (used between ART training images).

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -1,0 +1,267 @@
+from random import random, gauss
+
+from rate.RatePopulation import RatePopulation
+from rate.NormalizedMixtureNeuron import (
+    NormalizedMixtureNeuron, STREAM_BOTTOMUP, STREAM_TOPDOWN, STREAM_SELF)
+from rate.RateDiffuseReceptor import RateSomaticReceptorFactory, RateAxonalReceptorFactory
+
+'''
+Retinotopic grand-plan architecture (rate-based), with the primary visual area
+(V1) implementing the Sulfaro et al. (2023) normalized mixture of top-down and
+bottom-up input at the current level (see NormalizedMixtureNeuron).
+
+Areas
+-----
+  VisualInput   G*G retinotopic input cells (one per edge-detected pixel).
+  AudioInput    A tonotopic input cells, r=0.25 correlated to the visual input
+                (StructuredInput). Projects cross-modally to V1 -- these are the
+                remapping synapses that potentiate under serotonin when vision
+                is lost, exactly as in the validated two-region model.
+  V1pyr         G*G*cellsPerColumn NormalizedMixtureNeuron pyramidals. Each
+                cell's input current is the weight-normalized convex combination
+                of its three streams:
+                  bottom-up : VisualInput (topographic) + AudioInput (cross-modal)
+                  self      : V1 recurrent excitation + local FS inhibition
+                  top-down  : Category feedback (the secondary area)
+  V1fs          G*G*fsPerColumn fast-spiking interneurons (local E/I loop).
+  Category      K category cells forming the SECONDARY area: a competitive
+                one-hot classifier with a reject/vigilance option (ART-style,
+                first pass -- see below). Its winning category feeds back to V1
+                as the top-down stream.
+
+Streams and the Sulfaro knob
+----------------------------
+Each V1 pyramidal tags its inbound source populations into the three Sulfaro
+streams via assignStream(). The feedforward:feedback weighting ratio
+w_bottomup / w_topdown (params wBottomUp / wTopDown) is the perception knob:
+>1 veridical, <1 hallucination-prone (Sulfaro Fig. 3). Serotonergic 5HT2A gain
+on the bottom-up weight (setV1BottomUpGain) is Sulfaro's neurochemical bridge
+(5HT2A dampens V1 bottom-up gain; Seillier 2017, Michaiel 2019).
+
+Secondary classifier (first pass)
+---------------------------------
+The Category cells each hold a learned/handset template over V1 activity and
+compete by mutual inhibition; a category "wins" only if its match exceeds a
+vigilance threshold, otherwise the input is REJECTED (novel / potentially
+hallucinated). This first pass uses fixed templates (one per class prototype) so
+the top-down stream is well-defined and the V1 normalization can be exercised
+end to end; the ART learning/reset dynamics and the person/horse label wiring
+are deliberately left as a follow-up (they carry design choices -- number of
+categories, vigilance, template learning rule -- best set with the user).
+'''
+
+
+class RetinotopicGrandPlanNetwork:
+    def __init__(self, tau, params, name="RetinotopicGrandPlan"):
+        self.tau = tau
+        self.params = params
+        self.name = name
+        self.G = params["gridSize"]
+        self.nCols = self.G * self.G
+        self.cellsPerColumn = params["cellsPerColumn"]
+        self.fsPerColumn = params["fsPerColumn"]
+        self.audioBins = params["audioBins"]
+        self.categoryCount = params["categoryCount"]
+        self.populations = {}
+
+        transmitters = {"5HT2A": params["serotoninLevel"], "5HT1A": params["serotoninLevel"]}
+        somaP = [RateSomaticReceptorFactory("5HT2A", params["Somatic5HT2AWeight"]),
+                 RateSomaticReceptorFactory("5HT1A", params["Somatic5HT1AWeight"])]
+        axon5HT2A = [RateAxonalReceptorFactory("5HT2A", params["Axonal5HT2AWeight"])]
+        self._axon5HT2A = axon5HT2A
+
+        p = self.populations
+
+        # ---- input generators ----
+        p["VisualInput"] = RatePopulation(tau, None, self.nCols, [], {}, self, "VisualInput",
+                                          isInput=True, inputRate=0.0)
+        p["AudioInput"] = RatePopulation(tau, None, self.audioBins, [], {}, self, "AudioInput",
+                                         isInput=True, inputRate=0.0)
+
+        # ---- V1 area (mixture neurons) ----
+        wB, wT, wS = params["wBottomUp"], params["wTopDown"], params["wSelf"]
+
+        def mixtureFactory(tau_, cellType, nm, parentPop):
+            return NormalizedMixtureNeuron(tau_, cellType, nm, parentPop=parentPop,
+                                           w_bottomup=wB, w_topdown=wT, w_self=wS)
+
+        p["V1pyr"] = RatePopulation(tau, "Pyramidal", self.nCols * self.cellsPerColumn,
+                                    somaP, transmitters, self, "V1pyr",
+                                    neuronFactory=mixtureFactory)
+        p["V1fs"] = RatePopulation(tau, "FS", self.nCols * self.fsPerColumn,
+                                   [], transmitters, self, "V1fs")
+        # The leave-one-out ablation influence metric assumes additive currents;
+        # under the normalized mixture the marginal of a source is not its raw
+        # current, so we do not report that metric for V1 (see NormalizedMixtureNeuron).
+        p["V1pyr"].trackInfluence = False
+
+        # ---- secondary area: competitive classifier ----
+        p["Category"] = RatePopulation(tau, "Pyramidal", self.categoryCount,
+                                       somaP, transmitters, self, "Category")
+
+        # Cache each cell's index within its population so the connectivity weight
+        # functions are O(1) rather than O(n) (cells.index) inside the O(n^2) build.
+        for pop in p.values():
+            for i, cell in enumerate(pop.cells):
+                cell._idx = i
+
+        self._buildConnectivity(params)
+        self._assignV1Streams()
+
+    # ---- column index helpers ----
+
+    def _colOf(self, cellIndex, perColumn):
+        return cellIndex // perColumn
+
+    def _colXY(self, col):
+        return col % self.G, col // self.G
+
+    # ---- connectivity ----
+
+    def _buildConnectivity(self, params):
+        p = self.populations
+        G = self.G
+        cpc = self.cellsPerColumn
+        fpc = self.fsPerColumn
+        neigh = params["topographicRadius"]
+
+        # Bottom-up (topographic): VisualInput pixel (col) -> V1pyr cells in the
+        # same column and columns within topographicRadius (the pooling / RF
+        # analogue of Sulfaro's 13x13 ascending kernel).
+        def visualToV1(source, target):
+            srcCol = source._idx                    # input col == cell index
+            tgtCol = self._colOf(target._idx, cpc)
+            sx, sy = self._colXY(srcCol)
+            tx, ty = self._colXY(tgtCol)
+            if max(abs(sx - tx), abs(sy - ty)) <= neigh:
+                w = params["visualWeight"] / cpc
+                return gauss(w, abs(w) / 10)
+            return None
+        p["VisualInput"].addOutboundConnections(p["V1pyr"], visualToV1, self._axon5HT2A)
+
+        # Cross-modal bottom-up: AudioInput -> V1pyr, sparse all-to-all (the
+        # remapping synapses; weak at baseline, plastic under serotonin). Axonal
+        # 5HT2A on these transmission axons, as in the two-region model.
+        def audioToV1(source, target):
+            if random() < params["audioToV1Likelihood"]:
+                w = params["audioWeight"] / self.audioBins
+                return gauss(w, abs(w) / 10)
+            return None
+        p["AudioInput"].addOutboundConnections(p["V1pyr"], audioToV1, self._axon5HT2A)
+
+        # Self stream: V1 recurrent excitation within a column ...
+        def v1RecurrentExc(source, target):
+            si = source._idx
+            ti = target._idx
+            if self._colOf(si, cpc) == self._colOf(ti, cpc) and source is not target:
+                w = params["v1RecurrentWeight"] / cpc
+                return gauss(w, abs(w) / 10)
+            return None
+        p["V1pyr"].addOutboundConnections(p["V1pyr"], v1RecurrentExc)
+
+        # ... and the local E/I loop: V1pyr -> V1fs (drive) and V1fs -> V1pyr
+        # (inhibition), both within a column.
+        def v1ToFs(source, target):
+            si = source._idx
+            ti = target._idx
+            if self._colOf(si, cpc) == self._colOf(ti, fpc):
+                w = params["v1ToFsWeight"] / cpc
+                return gauss(w, abs(w) / 10)
+            return None
+        p["V1pyr"].addOutboundConnections(p["V1fs"], v1ToFs)
+
+        def fsToV1(source, target):
+            si = source._idx
+            ti = target._idx
+            if self._colOf(si, fpc) == self._colOf(ti, cpc):
+                w = params["fsToV1Weight"] / fpc
+                return gauss(w, abs(w) / 10)
+            return None
+        p["V1fs"].addOutboundConnections(p["V1pyr"], fsToV1)
+
+        # Feedforward pooling into the secondary area: all V1pyr -> each Category
+        # cell (the classifier reads the whole V1 map). Templates (per-category
+        # selectivity) live in the weight sign/magnitude; here a mild positive
+        # pooling weight, refined by template assignment in setCategoryTemplates.
+        def v1ToCategory(source, target):
+            w = params["v1ToCategoryWeight"] / (self.nCols * cpc)
+            return gauss(w, abs(w) / 10)
+        p["V1pyr"].addOutboundConnections(p["Category"], v1ToCategory)
+
+        # Lateral competition among Category cells (winner-take-all via mutual
+        # inhibition): each category inhibits the others.
+        def categoryCompetition(source, target):
+            if source is not target:
+                w = params["categoryInhibitionWeight"]
+                return gauss(w, abs(w) / 10)
+            return None
+        p["Category"].addOutboundConnections(p["Category"], categoryCompetition)
+
+        # Top-down feedback: Category -> V1pyr. The winning category projects its
+        # template back onto V1 as the top-down stream.
+        def categoryToV1(source, target):
+            w = params["categoryToV1Weight"] / self.categoryCount
+            return gauss(w, abs(w) / 10)
+        p["Category"].addOutboundConnections(p["V1pyr"], categoryToV1)
+
+    def _assignV1Streams(self):
+        # Tag each V1 pyramidal's inbound source populations into Sulfaro streams.
+        p = self.populations
+        streamByPop = {
+            p["VisualInput"]: STREAM_BOTTOMUP,
+            p["AudioInput"]: STREAM_BOTTOMUP,   # cross-modal ascending drive
+            p["V1pyr"]: STREAM_SELF,            # recurrent excitation
+            p["V1fs"]: STREAM_SELF,             # local inhibition (current-layer)
+            p["Category"]: STREAM_TOPDOWN,      # descending feedback
+        }
+        for cell in p["V1pyr"].cells:
+            for srcPop, stream in streamByPop.items():
+                cell.assignStream(srcPop, stream)
+
+    # ---- runtime controls ----
+
+    def setVisualRates(self, rates):
+        cells = self.populations["VisualInput"].cells
+        for cell, r in zip(cells, rates):
+            cell.setRate(float(r))
+
+    def setAudioRates(self, rates):
+        cells = self.populations["AudioInput"].cells
+        for cell, r in zip(cells, rates):
+            cell.setRate(float(r))
+
+    def setVisualScotoma(self, mask):
+        # mask: iterable of length nCols; True/1 -> that column's visual input
+        # is silenced (rate 0). Used for the scotoma / full-blindness tests.
+        cells = self.populations["VisualInput"].cells
+        for cell, silenced in zip(cells, mask):
+            if silenced:
+                cell.setRate(0.0)
+
+    def setSerotonin(self, level):
+        transmitters = {"5HT2A": level, "5HT1A": level}
+        for key in ("V1pyr", "V1fs", "Category"):
+            self.populations[key].setDiffuseTransmitters(dict(transmitters))
+
+    def set5HT2A(self, level):
+        # Raise only 5HT2A (pharmacological / agonist), 5HT1A at baseline.
+        base = self.params["serotoninLevel"]
+        transmitters = {"5HT2A": level, "5HT1A": base}
+        for key in ("V1pyr", "V1fs", "Category"):
+            self.populations[key].setDiffuseTransmitters(dict(transmitters))
+
+    def setV1BottomUpGain(self, gain):
+        # Sulfaro neurochemical bridge: scale the bottom-up stream weight on every
+        # V1 pyramidal (5HT2A dampening of bottom-up gain -> gain < 1).
+        for cell in self.populations["V1pyr"].cells:
+            cell.bottomUpGain = float(gain)
+
+    def audioRemappingAxons(self):
+        # The cross-modal AudioInput -> V1pyr synapses (analogue of S_B -> P_A).
+        return self.populations["AudioInput"].outboundAxonsTo(self.populations["V1pyr"])
+
+    def step(self):
+        for population in self.populations.values():
+            population.stepCells()
+        for population in self.populations.values():
+            population.stepOutputs()

--- a/rate/RetinotopicGrandPlanNetwork.py
+++ b/rate/RetinotopicGrandPlanNetwork.py
@@ -313,11 +313,35 @@ class RetinotopicGrandPlanNetwork:
         gain = max(floor, min(1.0, gain))
         self.setV1BottomUpGain(gain)
 
-    def setV1BottomUpGain(self, gain):
-        # Scale the bottom-up stream weight on every V1 pyramidal. Called by the
-        # serotonin coupling above, and directly by analyses that sweep the gain.
-        for cell in self.populations["V1pyr"].cells:
+    def setV1BottomUpGain(self, gain, cells=None):
+        # Scale the bottom-up stream weight on V1 pyramidals (all, or a subset --
+        # e.g. the deprived region). Called by the serotonin coupling, by analyses
+        # that sweep the gain, and by the Realistic-5HT manipulation.
+        cells = self.populations["V1pyr"].cells if cells is None else cells
+        for cell in cells:
             cell.bottomUpGain = float(gain)
+
+    def setV1SomaticSerotonin(self, level, cells=None):
+        # Set the somatic 5HT receptor level (both 5HT2A and 5HT1A) on V1
+        # pyramidals (all, or a subset -- e.g. the deprived region), directly on
+        # the receptors. Used by Realistic-5HT to REDUCE serotonin in deprived
+        # visual cortex. Bypasses the population transmitter dict (which the
+        # Realistic path does not read), so somatic V1 serotonin can move
+        # independently of the cross-modal axonal serotonin.
+        cells = self.populations["V1pyr"].cells if cells is None else cells
+        for cell in cells:
+            for receptor in cell.diffuseReceptors:
+                receptor.setLevel(float(level))
+
+    def setCrossModalAxonalSerotonin(self, level, axons=None):
+        # Set the axonal 5HT receptor level on the cross-modal AudioInput -> V1
+        # remapping axons (all, or a subset), raising transmission (lowering
+        # failure). Used by Realistic-5HT to INCREASE serotonin on the auditory
+        # cross-modal input, independently of somatic V1 serotonin.
+        axons = self.audioRemappingAxons() if axons is None else axons
+        for axon in axons:
+            for receptor in axon.axonalReceptors:
+                receptor.setLevel(float(level))
 
     def audioRemappingAxons(self):
         # The cross-modal AudioInput -> V1pyr synapses (analogue of S_B -> P_A).

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -102,7 +102,7 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     # activity signal (cortico-raphe feedback substrate; Celada 2001).
     params["emergent5HT"] = False
     params["homeostaticTau"] = 800.0          # controller ramp time constant (ms)
-    params["homeostaticTauRelax"] = 3000.0     # RELAX time constant (ms); > tau makes the
+    params["homeostaticTauRelax"] = 6000.0     # RELAX time constant (ms); > tau makes the
                                                # homeostatic changes persist after activity
                                                # recovers (intrinsic/scaling changes reverse
                                                # slowly) -> underdamped -> transient overshoot

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -55,6 +55,15 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     params["categoryInhibitionWeight"] = -50.0   # winner-take-all lateral inhibition
     params["categoryVigilance"] = 5.0        # reject threshold (Hz); below -> no category wins
 
+    # --- serotonin -> Sulfaro mixture coupling ---
+    # When on, raising 5HT2A lowers the V1 bottom-up stream weight (bottomUpGain),
+    # tipping the feedforward:feedback ratio toward feedback (Sulfaro/Seillier
+    # bridge). Supplements the existing somatic (additive) and axonal
+    # (transmission) serotonin effects. See _updateMixtureFromSerotonin.
+    params["serotoninShiftsMixture"] = True
+    params["bottomUpGainDamp"] = 0.2         # gain = 1 - damp*(L-base)/base
+    params["minBottomUpGain"] = 0.1          # floor on bottom-up gain
+
     # --- ART secondary area (used when useART=True) ---
     params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down
     params["artVigilance"] = 0.75            # ART vigilance rho (reject threshold)

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -50,10 +50,17 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     params["fsToV1Weight"] = -300.0          # self loop: FS -> V1 inhibition
     params["categoryToV1Weight"] = 400.0     # top-down: Category -> V1 feedback
 
-    # --- secondary competitive classifier ---
+    # --- secondary competitive classifier (first-pass, used when useART=False) ---
     params["v1ToCategoryWeight"] = 500.0     # feedforward pooling V1 -> Category
     params["categoryInhibitionWeight"] = -50.0   # winner-take-all lateral inhibition
     params["categoryVigilance"] = 5.0        # reject threshold (Hz); below -> no category wins
+
+    # --- ART secondary area (used when useART=True) ---
+    params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down
+    params["artVigilance"] = 0.75            # ART vigilance rho (reject threshold)
+    params["artActivityFloor"] = 0.05        # feature-mean floor below which -> reject
+    params["artReferenceRate"] = 6.0         # V1 Hz mapping to feature value 1.0
+    params["topDownDriveHz"] = 30.0          # Hz that template value 1.0 projects back as
 
     # --- plasticity (audio remapping synapses), reusing the validated rule ---
     # Tuned (with audioWeight/ceiling) so the potentiated cross-modal drive is

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -107,7 +107,9 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
                                                # recovers (intrinsic/scaling changes reverse
                                                # slowly) -> underdamped -> transient overshoot
     params["homeostaticUpdateEvery"] = 50      # steps between controller updates
-    params["homeostaticGain"] = 1.4            # deficit->h loop gain (>1 allows overshoot)
+    params["homeostaticGain"] = 2.5            # deficit->h loop gain; with the slow relax
+                                               # above this gives a clear (~+8%) transient
+                                               # hyperactivity overshoot that then settles
 
     # --- ART secondary area (used when useART=True) ---
     params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -64,6 +64,20 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     params["bottomUpGainDamp"] = 0.2         # gain = 1 - damp*(L-base)/base
     params["minBottomUpGain"] = 0.1          # floor on bottom-up gain
 
+    # --- "Realistic 5HT" phase-3 mechanism (opt-in) ---
+    # Literature-grounded reframing of the deafferentation serotonin response
+    # (5HT2A/3A modulation of deprived visual cortex + cross-modal input). When
+    # on, phase 3 does NOT raise a single uniform 5HT; instead, in the DEPRIVED
+    # region it (i) reduces somatic 5HT in visual cortex, (ii) raises V1 gain
+    # (disinhibition -> higher bottom-up stream weight), (iii) raises 5HT on the
+    # cross-modal audio->V1 transmission axons, and (iv) lowers the plasticity
+    # threshold. All four are consistent with 5HT2A/3A modulation.
+    params["realistic5HT"] = False
+    params["v1SerotoninDeprived"] = 2.0          # reduced somatic 5HT in deprived V1 (baseline 10)
+    params["v1BottomUpGainDeprived"] = 1.5       # raised gain (disinhibition) in deprived region
+    params["crossModalSerotoninLevel"] = 40.0    # raised 5HT on audio->V1 transmission axons
+    params["plasticityThresholdDeprived"] = 1.0  # lowered plasticity threshold (baseline 3.0)
+
     # --- ART secondary area (used when useART=True) ---
     params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down
     params["artVigilance"] = 0.75            # ART vigilance rho (reject threshold)

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -88,6 +88,23 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     # bootstrap. Relaxes at return as remapping restores drive (set to 0 in phase 4).
     params["intrinsicExcitabilityDrive"] = 60.0  # tonic depolarizing offset (deprived region, phase 3)
 
+    # --- "Emergent Realistic 5HT" (opt-in): closed-loop, activity-driven ---
+    # Instead of imposing the phase-3 responses on a schedule, a homeostatic
+    # controller reads the deprived region's activity deficit each update and
+    # ramps ALL responses (intrinsic excitability, bottom-up gain, reduced V1
+    # 5HT, raised cross-modal 5HT, lowered plasticity threshold) in proportion to
+    # a single latent drive h in [0,1]; h relaxes as remapping restores activity.
+    # The only imposed event is the sensory loss; the drop -> hyperactivity ->
+    # settle trajectory then emerges (and self-limits) from the loop. The
+    # response VALUES at h=1 are the realistic5HT constants above; at h=0 they
+    # equal baseline. Grounded in firing-rate / intrinsic-excitability homeostasis
+    # (Turrigiano; Desai 1999) with the raphe/5HT2A-3A responses tied to the same
+    # activity signal (cortico-raphe feedback substrate; Celada 2001).
+    params["emergent5HT"] = False
+    params["homeostaticTau"] = 800.0          # controller time constant (ms)
+    params["homeostaticUpdateEvery"] = 50      # steps between controller updates
+    params["homeostaticGain"] = 1.4            # deficit->h loop gain (>1 allows overshoot)
+
     # --- ART secondary area (used when useART=True) ---
     params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down
     params["artVigilance"] = 0.75            # ART vigilance rho (reject threshold)

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -1,0 +1,65 @@
+def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
+    """Parameters for the retinotopic grand-plan architecture.
+
+    Defaults target the user's spec: a 10x10 retinotopic grid (100 visual
+    columns), a small population per column (8 pyramidal + 2 FS), 20 tonotopic
+    audio bins, and a 2-category secondary classifier (person / horse). The
+    grid size is a constructor argument so the self-check can run a small, fast
+    network while the target architecture stays the default.
+
+    Weights are on the rate model's validated current scale. The Sulfaro
+    perception knob is (wBottomUp, wTopDown): their ratio governs veridical vs
+    top-down/hallucinatory V1, and both default to 1 (Sulfaro's neutral scheme).
+    """
+    params = {}
+    params["tau"] = 0.1
+    params["epochDurationMs"] = 1000
+    params["warmupMs"] = 300
+
+    # Architecture size
+    params["gridSize"] = gridSize
+    params["cellsPerColumn"] = cellsPerColumn
+    params["fsPerColumn"] = 2
+    params["audioBins"] = 20
+    params["categoryCount"] = categoryCount
+    params["topographicRadius"] = 1          # V1 receptive-field radius (columns)
+
+    # Input drive range (Hz), used by StructuredInput to scale [0,1] -> rate.
+    params["minRateHz"] = 0.0
+    params["maxRateHz"] = 30.0
+
+    # --- Sulfaro normalized-mixture stream weights (the perception knob) ---
+    params["wBottomUp"] = 1.0                # w_{l-1}: ascending / sensory
+    params["wTopDown"] = 1.0                 # w_{l+1}: descending / feedback
+    params["wSelf"] = 1.0                    # w_l: current-layer recurrent
+
+    # Diffuse serotonin (baseline). setSerotonin / set5HT2A change it at runtime.
+    params["serotoninLevel"] = 10.0
+    params["Somatic5HT2AWeight"] = 5.0
+    params["Somatic5HT1AWeight"] = -1.0
+    params["Axonal5HT2AWeight"] = 0.005      # base failure 0.25 -> ~20% at 5HT2A=10
+
+    # --- stream currents into V1 (pre-normalization magnitudes) ---
+    # These set each stream's raw synaptic current; the mixture then normalizes
+    # by the stream WEIGHTS above, so absolute rates stay in a sane range.
+    params["visualWeight"] = 500.0           # bottom-up: VisualInput -> V1 (topographic)
+    params["audioWeight"] = 150.0            # bottom-up cross-modal: AudioInput -> V1 (remapping)
+    params["audioToV1Likelihood"] = 0.3
+    params["v1RecurrentWeight"] = 120.0      # self: within-column recurrent excitation
+    params["v1ToFsWeight"] = 300.0           # self loop: V1 -> FS drive
+    params["fsToV1Weight"] = -300.0          # self loop: FS -> V1 inhibition
+    params["categoryToV1Weight"] = 400.0     # top-down: Category -> V1 feedback
+
+    # --- secondary competitive classifier ---
+    params["v1ToCategoryWeight"] = 500.0     # feedforward pooling V1 -> Category
+    params["categoryInhibitionWeight"] = -50.0   # winner-take-all lateral inhibition
+    params["categoryVigilance"] = 5.0        # reject threshold (Hz); below -> no category wins
+
+    # --- plasticity (audio remapping synapses), reusing the validated rule ---
+    params["gamma_p"] = 50.0
+    params["gamma_d"] = 5e-4
+    params["plasticityThreshold"] = 3.0
+    params["plasticityCeilingFactor"] = 4.0
+    params["remapSerotoninLevel"] = 40.0
+
+    return params

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -73,10 +73,20 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     # cross-modal audio->V1 transmission axons, and (iv) lowers the plasticity
     # threshold. All four are consistent with 5HT2A/3A modulation.
     params["realistic5HT"] = False
-    params["v1SerotoninDeprived"] = 2.0          # reduced somatic 5HT in deprived V1 (baseline 10)
-    params["v1BottomUpGainDeprived"] = 1.5       # raised gain (disinhibition) in deprived region
+    params["v1SerotoninDeprived"] = 8.0          # mildly reduced somatic 5HT in deprived V1 (baseline 10)
+    params["v1BottomUpGainDeprived"] = 1.5       # raised bottom-up gain in deprived region (5HT2A)
     params["crossModalSerotoninLevel"] = 40.0    # raised 5HT on audio->V1 transmission axons
     params["plasticityThresholdDeprived"] = 1.0  # lowered plasticity threshold (baseline 3.0)
+    # Deprivation-induced INTRINSIC EXCITABILITY homeostasis (Desai, Rutherford &
+    # Turrigiano 1999; the firing-rate-homeostasis literature). This is the
+    # NON-serotonergic driver of the transient hyperactivity: an input-INDEPENDENT
+    # tonic depolarization of the deprived region during the reorganization phase.
+    # It is required because neither bottom-up gain (amplifies absent input) nor
+    # disinhibition (removes absent activity-driven inhibition) can raise firing in
+    # a cortex that has lost its feedforward drive; the hyperactivity in turn
+    # provides the postsynaptic activity the Hebbian cross-modal remapping needs to
+    # bootstrap. Relaxes at return as remapping restores drive (set to 0 in phase 4).
+    params["intrinsicExcitabilityDrive"] = 60.0  # tonic depolarizing offset (deprived region, phase 3)
 
     # --- ART secondary area (used when useART=True) ---
     params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -111,6 +111,24 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
                                                # above this gives a clear (~+8%) transient
                                                # hyperactivity overshoot that then settles
 
+    # --- v3.1: sequence input, sound bank, switchable slow classifier ---
+    # A shuffled image sequence + discrete sound clips loosely correlated to
+    # class, read out by a switchable unsupervised classifier that learns slowly
+    # at all points, so new audio-driven categories can emerge under blindness.
+    # remapLearningRate (= gamma_p) and classifierLearningRate are the two
+    # DECOUPLED, runtime-set rates: the first drives activity recovery, the
+    # second is the slow category learning. See V3.1_Plan.md.
+    params["classifierType"] = "FUZZY_ART"       # FUZZY_ART | FUZZY_ARTMAP | KNN
+    params["classifierLearningRate"] = 0.05      # ART beta / KNN centroid step (SLOW)
+    params["knnDistanceVigilance"] = 0.30        # KNN: spawn a new prototype beyond this dist
+    params["presentationMs"] = 100.0             # duration of each image presentation
+    params["baselineMs"] = 2000.0                # sighted baseline (plasticity ON)
+    params["postLossMs"] = 20000.0               # deprivation -> recovery -> long stable window
+    params["snapshotEvery"] = 20                 # presentations between classifier snapshots
+    params["soundBankSize"] = None               # None -> = class count; may exceed it
+    params["soundClassMatchProb"] = 0.25          # P(canonical clip) -> clip/class association
+    params["homeostaticActivityTau"] = 500.0     # EMA tau for controller's activity read (ms)
+
     # --- ART secondary area (used when useART=True) ---
     params["useART"] = False                 # opt-in: Fuzzy ART classifier drives top-down
     params["artVigilance"] = 0.75            # ART vigilance rho (reject threshold)

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -101,7 +101,11 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     # (Turrigiano; Desai 1999) with the raphe/5HT2A-3A responses tied to the same
     # activity signal (cortico-raphe feedback substrate; Celada 2001).
     params["emergent5HT"] = False
-    params["homeostaticTau"] = 800.0          # controller time constant (ms)
+    params["homeostaticTau"] = 800.0          # controller ramp time constant (ms)
+    params["homeostaticTauRelax"] = 3000.0     # RELAX time constant (ms); > tau makes the
+                                               # homeostatic changes persist after activity
+                                               # recovers (intrinsic/scaling changes reverse
+                                               # slowly) -> underdamped -> transient overshoot
     params["homeostaticUpdateEvery"] = 50      # steps between controller updates
     params["homeostaticGain"] = 1.4            # deficit->h loop gain (>1 allows overshoot)
 

--- a/rate/RetinotopicGrandPlanParams.py
+++ b/rate/RetinotopicGrandPlanParams.py
@@ -43,7 +43,7 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     # These set each stream's raw synaptic current; the mixture then normalizes
     # by the stream WEIGHTS above, so absolute rates stay in a sane range.
     params["visualWeight"] = 500.0           # bottom-up: VisualInput -> V1 (topographic)
-    params["audioWeight"] = 150.0            # bottom-up cross-modal: AudioInput -> V1 (remapping)
+    params["audioWeight"] = 300.0            # bottom-up cross-modal: AudioInput -> V1 (remapping)
     params["audioToV1Likelihood"] = 0.3
     params["v1RecurrentWeight"] = 120.0      # self: within-column recurrent excitation
     params["v1ToFsWeight"] = 300.0           # self loop: V1 -> FS drive
@@ -56,10 +56,14 @@ def buildGrandPlanParams(gridSize=10, cellsPerColumn=8, categoryCount=2):
     params["categoryVigilance"] = 5.0        # reject threshold (Hz); below -> no category wins
 
     # --- plasticity (audio remapping synapses), reusing the validated rule ---
-    params["gamma_p"] = 50.0
+    # Tuned (with audioWeight/ceiling) so the potentiated cross-modal drive is
+    # strong enough to functionally restore deprived-column firing after the
+    # normalized mixture's weight-sum division, and to persist into the return
+    # epoch -- while the no-plasticity control shows no recovery.
+    params["gamma_p"] = 200.0
     params["gamma_d"] = 5e-4
     params["plasticityThreshold"] = 3.0
-    params["plasticityCeilingFactor"] = 4.0
+    params["plasticityCeilingFactor"] = 8.0
     params["remapSerotoninLevel"] = 40.0
 
     return params

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -89,11 +89,19 @@ class RetinotopicGrandPlanSimulation:
         # Realistic-5HT the manipulation is confined to the DEPRIVED region, so we
         # use only the audio->V1 axons that target deprived cells (for full
         # blindness that is all of them); the legacy path uses all remapping axons.
-        if params.get("realistic5HT", False):
+        self.emergent = params.get("emergent5HT", False)
+        if params.get("realistic5HT", False) or self.emergent:
             deprivedSet = set(self.deprivedCells)
             self.plasticAxons = [a for a in self.remapping if a.target in deprivedSet]
         else:
             self.plasticAxons = self.remapping
+
+        # Emergent (closed-loop) controller state.
+        self.homeostaticH = 0.0        # latent deprivation drive h in [0,1]
+        self.A_set = None              # baseline activity set-point (deprived region)
+        self._controllerActive = False
+        self._ctrlEvery = int(params.get("homeostaticUpdateEvery", 50))
+        self._ctrlCount = 0
 
         # Retinotopic geometry for plotting.
         G = self.network.G
@@ -109,6 +117,7 @@ class RetinotopicGrandPlanSimulation:
         self.visualCurrent = []
         self.topDownCurrent = []
         self.remapWeight = []
+        self.homeostaticDrive = []   # controller h over time (emergent mode)
         self.v1MapsByEpoch = {}   # epoch index -> G x G V1 column-rate snapshot
         # ART decision time series (only populated when useART). artClass encodes
         # the decision numerically: the class label, or REJECT (-1) on reject.
@@ -185,6 +194,7 @@ class RetinotopicGrandPlanSimulation:
         self.visualCurrent.append(np.mean([c.lastSourceCurrent.get(self._visualPop, 0.0) for c in sc]) if sc else float("nan"))
         self.topDownCurrent.append(np.mean([c.lastStreamCurrent[STREAM_TOPDOWN] for c in sc]) if sc else float("nan"))
         self.remapWeight.append(float(np.mean([a.weight for a in self.plasticAxons])) if self.plasticAxons else float("nan"))
+        self.homeostaticDrive.append(self.homeostaticH)
         if self.network.useART:
             d = self.network.lastART
             self.artReject.append(bool(d["reject"]))
@@ -196,14 +206,51 @@ class RetinotopicGrandPlanSimulation:
 
     def _stepFor(self, durationMs, record=True):
         for _ in np.arange(0.0, durationMs, self.tau):
+            if self._controllerActive:
+                self._ctrlCount += 1
+                if self._ctrlCount % self._ctrlEvery == 0:
+                    self._controllerStep()
             self.network.step()
             if record:
                 self._record()
 
+    # ---- emergent (closed-loop) homeostatic controller ----
+
+    def _deprivedActivity(self):
+        sc = self.deprivedCells
+        return float(np.mean([c.rate for c in sc])) if sc else 0.0
+
+    def _controllerStep(self):
+        # Read the deprived region's activity deficit and low-pass it into the
+        # latent drive h, then scale every deprivation response by h. h relaxes
+        # as remapping restores activity, so the whole trajectory self-limits.
+        p = self.params
+        A = self._deprivedActivity()
+        deficit = 0.0 if not self.A_set else max(0.0, (self.A_set - A) / self.A_set)
+        target = min(1.0, p.get("homeostaticGain", 1.4) * deficit)
+        dt = self._ctrlEvery * self.tau
+        self.homeostaticH += (dt / p["homeostaticTau"]) * (target - self.homeostaticH)
+        self.homeostaticH = min(1.0, max(0.0, self.homeostaticH))
+        self._applyEmergentResponses(self.homeostaticH)
+
+    def _applyEmergentResponses(self, h):
+        # Interpolate every response from baseline (h=0) to its realistic5HT
+        # "full deprivation" value (h=1); tie the cross-modal serotonin and the
+        # plasticity threshold to the same drive.
+        p = self.params
+        base5ht = p["serotoninLevel"]
+        self.network.setDeprivedIntrinsicDrive(h * p["intrinsicExcitabilityDrive"], self.deprivedCells)
+        self.network.setV1BottomUpGain(1.0 + h * (p["v1BottomUpGainDeprived"] - 1.0), self.deprivedCells)
+        self.network.setV1SomaticSerotonin(base5ht - h * (base5ht - p["v1SerotoninDeprived"]), self.deprivedCells)
+        self.network.setCrossModalAxonalSerotonin(base5ht + h * (p["crossModalSerotoninLevel"] - base5ht), self.plasticAxons)
+        thr = p["plasticityThreshold"] - h * (p["plasticityThreshold"] - p["plasticityThresholdDeprived"])
+        for a in self.plasticAxons:
+            a.plasticityThreshold = thr
+
     def _resetRecords(self):
         self.epochBoundaries = []
         for key in ("rateDeprived", "rateIntact", "audioCurrent",
-                    "visualCurrent", "topDownCurrent", "remapWeight",
+                    "visualCurrent", "topDownCurrent", "remapWeight", "homeostaticDrive",
                     "artClass", "artReject", "artMatch", "artCategory"):
             setattr(self, key, [])
 
@@ -281,9 +328,39 @@ class RetinotopicGrandPlanSimulation:
         self._endEpoch(4)
 
     def run(self):
+        if self.emergent:
+            return self._run_emergent()
         self.warmup()
         self.epoch1_baseline()
         self.epoch2_loss()
         self.epoch3_serotonin_plasticity()
         self.epoch4_return()
+        return self
+
+    def _run_emergent(self):
+        # Closed loop: the ONLY imposed event is the sensory loss at the start of
+        # epoch 2. Everything else -- the drop, the hyperactivity overshoot, the
+        # remapping, the settle -- emerges from the homeostatic controller reading
+        # the activity deficit. Epochs 2-4 are just equal-length observation
+        # windows (time markers), not imposed transitions.
+        p = self.params
+        self.warmup()
+        self.epoch1_baseline()
+        # Set-point = the deprived region's own baseline activity (second half of epoch 1).
+        half = len(self.rateDeprived) // 2
+        self.A_set = float(np.nanmean(self.rateDeprived[half:])) if self.rateDeprived else None
+
+        # Impose loss; enable plasticity (reduced rate, dynamic threshold set by
+        # the controller); activate the controller. Nothing else is scheduled.
+        self.network.setVisualScotoma(self.silencedColumns)
+        if self.plasticityEnabled:
+            for axon in self.plasticAxons:
+                axon.enablePlasticity(p["gamma_p"], p["gamma_d"], p["plasticityThreshold"],
+                                      ceilingFactor=p["plasticityCeilingFactor"])
+        self._controllerActive = True
+        for epoch in (2, 3, 4):
+            self._stepFor(self.epochDurationMs)
+            self._endEpoch(epoch)
+        for axon in self.plasticAxons:
+            axon.disablePlasticity()
         return self

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -355,6 +355,12 @@ class RetinotopicGrandPlanSimulation:
         # Set-point = the deprived region's own baseline activity (second half of epoch 1).
         half = len(self.rateDeprived) // 2
         self.A_set = float(np.nanmean(self.rateDeprived[half:])) if self.rateDeprived else None
+        # Optional resilience hook: a caller may set self.checkpointFn to dump the
+        # partial recorded state after each epoch, so a container/worker restart
+        # mid-run loses at most one epoch instead of the whole (multi-hour) job.
+        ckpt = getattr(self, "checkpointFn", None)
+        if ckpt is not None:
+            ckpt(self, 1)
 
         # Impose loss; enable plasticity (reduced rate, dynamic threshold set by
         # the controller); activate the controller. Nothing else is scheduled.
@@ -367,6 +373,8 @@ class RetinotopicGrandPlanSimulation:
         for epoch in (2, 3, 4):
             self._stepFor(self.epochDurationMs)
             self._endEpoch(epoch)
+            if ckpt is not None:
+                ckpt(self, epoch)
         for axon in self.plasticAxons:
             axon.disablePlasticity()
         return self

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -72,6 +72,12 @@ class RetinotopicGrandPlanSimulation:
         self.deprivedColumns = self._deprivedColumns(self.silencedColumns)
         self.deprivedCells, self.intactCells = self._partitionV1Cells()
 
+        # Retinotopic geometry for plotting.
+        G = self.network.G
+        self.inputGrid = np.asarray(stimulus.visualGrid, dtype=float)
+        self.silencedMap = np.array(self.silencedColumns).reshape(G, G)
+        self.deprivedMap = np.array(self.deprivedColumns).reshape(G, G)
+
         # Records
         self.epochBoundaries = []
         self.rateDeprived = []
@@ -80,6 +86,7 @@ class RetinotopicGrandPlanSimulation:
         self.visualCurrent = []
         self.topDownCurrent = []
         self.remapWeight = []
+        self.v1MapsByEpoch = {}   # epoch index -> G x G V1 column-rate snapshot
 
         self._audioPop = self.network.populations["AudioInput"]
         self._visualPop = self.network.populations["VisualInput"]
@@ -163,8 +170,20 @@ class RetinotopicGrandPlanSimulation:
                     "visualCurrent", "topDownCurrent", "remapWeight"):
             setattr(self, key, [])
 
+    def v1ColumnMap(self):
+        # G x G map of per-column mean V1 pyramidal rate (retinotopic snapshot).
+        G = self.network.G
+        cpc = self.network.cellsPerColumn
+        cells = self.network.populations["V1pyr"].cells
+        m = np.array([np.mean([cells[c * cpc + k].rate for k in range(cpc)])
+                      for c in range(G * G)])
+        return m.reshape(G, G)
+
     def _endEpoch(self, epoch):
         self.epochBoundaries.append(self.epochDurationMs * epoch)
+        # Retinotopic V1 snapshot at the end of this epoch, so we can show the
+        # deprived region darken at loss and partially re-light after remapping.
+        self.v1MapsByEpoch[epoch] = self.v1ColumnMap()
 
     def warmup(self):
         self._stepFor(self.warmupMs, record=False)

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from rate.RetinotopicGrandPlanNetwork import RetinotopicGrandPlanNetwork
+from rate.RetinotopicGrandPlanNetwork import RetinotopicGrandPlanNetwork, pretrainART
 from rate.NormalizedMixtureNeuron import STREAM_TOPDOWN
+from rate.ARTClassifier import FuzzyART, REJECT
 
 '''
 Sensory-loss experiment on the retinotopic grand-plan architecture, mirroring
@@ -62,7 +63,19 @@ class RetinotopicGrandPlanSimulation:
         self.stimulus = stimulus
         self.remapping = self.network.audioRemappingAxons()   # AudioInput -> V1pyr
 
+        # If the secondary area is ART, build and pre-train the classifier on the
+        # V1 representations of the labeled stimuli, then activate it. Done before
+        # presenting the experiment stimulus so training sees clean bottom-up V1.
+        self.art = None
+        if self.network.useART:
+            self.art = FuzzyART(dim=self.network.nCols, vigilance=params["artVigilance"],
+                                alpha=0.01, beta=1.0, activity_floor=params["artActivityFloor"])
+            pretrainART(self.network, inputSet, self.art,
+                        settleMs=params.get("artPretrainSettleMs", 200.0))
+            self.network.setARTActive(True)
+
         # Present the stimulus (held fixed across epochs; only the mask changes).
+        self.network.resetActivity()
         self.network.setVisualRates(inputSet.visualRates(stimulus))
         self.network.setAudioRates(inputSet.audioRates(stimulus))
 
@@ -87,6 +100,12 @@ class RetinotopicGrandPlanSimulation:
         self.topDownCurrent = []
         self.remapWeight = []
         self.v1MapsByEpoch = {}   # epoch index -> G x G V1 column-rate snapshot
+        # ART decision time series (only populated when useART). artClass encodes
+        # the decision numerically: the class label, or REJECT (-1) on reject.
+        self.artClass = []
+        self.artReject = []
+        self.artMatch = []
+        self.trueLabel = stimulus.label
 
         self._audioPop = self.network.populations["AudioInput"]
         self._visualPop = self.network.populations["VisualInput"]
@@ -155,6 +174,11 @@ class RetinotopicGrandPlanSimulation:
         self.visualCurrent.append(np.mean([c.lastSourceCurrent.get(self._visualPop, 0.0) for c in sc]) if sc else float("nan"))
         self.topDownCurrent.append(np.mean([c.lastStreamCurrent[STREAM_TOPDOWN] for c in sc]) if sc else float("nan"))
         self.remapWeight.append(float(np.mean([a.weight for a in self.remapping])) if self.remapping else float("nan"))
+        if self.network.useART:
+            d = self.network.lastART
+            self.artReject.append(bool(d["reject"]))
+            self.artClass.append(REJECT if d["reject"] else int(d["label"]))
+            self.artMatch.append(float(d["match"]))
 
     # ---- run ----
 
@@ -167,7 +191,8 @@ class RetinotopicGrandPlanSimulation:
     def _resetRecords(self):
         self.epochBoundaries = []
         for key in ("rateDeprived", "rateIntact", "audioCurrent",
-                    "visualCurrent", "topDownCurrent", "remapWeight"):
+                    "visualCurrent", "topDownCurrent", "remapWeight",
+                    "artClass", "artReject", "artMatch"):
             setattr(self, key, [])
 
     def v1ColumnMap(self):

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -85,6 +85,16 @@ class RetinotopicGrandPlanSimulation:
         self.deprivedColumns = self._deprivedColumns(self.silencedColumns)
         self.deprivedCells, self.intactCells = self._partitionV1Cells()
 
+        # Axons that undergo plasticity / cross-modal serotonin modulation. Under
+        # Realistic-5HT the manipulation is confined to the DEPRIVED region, so we
+        # use only the audio->V1 axons that target deprived cells (for full
+        # blindness that is all of them); the legacy path uses all remapping axons.
+        if params.get("realistic5HT", False):
+            deprivedSet = set(self.deprivedCells)
+            self.plasticAxons = [a for a in self.remapping if a.target in deprivedSet]
+        else:
+            self.plasticAxons = self.remapping
+
         # Retinotopic geometry for plotting.
         G = self.network.G
         self.inputGrid = np.asarray(stimulus.visualGrid, dtype=float)
@@ -174,7 +184,7 @@ class RetinotopicGrandPlanSimulation:
         self.audioCurrent.append(np.mean([c.lastSourceCurrent.get(self._audioPop, 0.0) for c in sc]) if sc else float("nan"))
         self.visualCurrent.append(np.mean([c.lastSourceCurrent.get(self._visualPop, 0.0) for c in sc]) if sc else float("nan"))
         self.topDownCurrent.append(np.mean([c.lastStreamCurrent[STREAM_TOPDOWN] for c in sc]) if sc else float("nan"))
-        self.remapWeight.append(float(np.mean([a.weight for a in self.remapping])) if self.remapping else float("nan"))
+        self.remapWeight.append(float(np.mean([a.weight for a in self.plasticAxons])) if self.plasticAxons else float("nan"))
         if self.network.useART:
             d = self.network.lastART
             self.artReject.append(bool(d["reject"]))
@@ -226,19 +236,40 @@ class RetinotopicGrandPlanSimulation:
         self._endEpoch(2)
 
     def epoch3_serotonin_plasticity(self):
-        self.network.setSerotonin(self.params["remapSerotoninLevel"])
+        p = self.params
+        if p.get("realistic5HT", False):
+            # Realistic (5HT2A/3A-consistent) deafferentation response, confined
+            # to the deprived region + its cross-modal input:
+            #  (i)  reduce somatic 5HT in deprived visual cortex,
+            #  (ii) raise V1 gain there (disinhibition),
+            #  (iii)raise 5HT on the cross-modal audio->V1 transmission,
+            #  (iv) lower the plasticity threshold.
+            self.network.setV1SomaticSerotonin(p["v1SerotoninDeprived"], self.deprivedCells)
+            self.network.setV1BottomUpGain(p["v1BottomUpGainDeprived"], self.deprivedCells)
+            self.network.setCrossModalAxonalSerotonin(p["crossModalSerotoninLevel"], self.plasticAxons)
+            plasticThreshold = p["plasticityThresholdDeprived"]
+        else:
+            self.network.setSerotonin(p["remapSerotoninLevel"])
+            plasticThreshold = p["plasticityThreshold"]
+
         if self.plasticityEnabled:
-            for axon in self.remapping:
-                axon.enablePlasticity(self.params["gamma_p"], self.params["gamma_d"],
-                                      self.params["plasticityThreshold"],
-                                      ceilingFactor=self.params["plasticityCeilingFactor"])
+            for axon in self.plasticAxons:
+                axon.enablePlasticity(p["gamma_p"], p["gamma_d"], plasticThreshold,
+                                      ceilingFactor=p["plasticityCeilingFactor"])
         self._stepFor(self.epochDurationMs)
-        for axon in self.remapping:
+        for axon in self.plasticAxons:
             axon.disablePlasticity()
         self._endEpoch(3)
 
     def epoch4_return(self):
-        self.network.setSerotonin(self.params["serotoninLevel"])
+        p = self.params
+        if p.get("realistic5HT", False):
+            # Restore the deprived region and its cross-modal input to baseline.
+            self.network.setV1SomaticSerotonin(p["serotoninLevel"], self.deprivedCells)
+            self.network.setV1BottomUpGain(1.0, self.deprivedCells)
+            self.network.setCrossModalAxonalSerotonin(p["serotoninLevel"], self.plasticAxons)
+        else:
+            self.network.setSerotonin(p["serotoninLevel"])
         self._stepFor(self.epochDurationMs)
         self._endEpoch(4)
 

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -1,0 +1,205 @@
+import numpy as np
+
+from rate.RetinotopicGrandPlanNetwork import RetinotopicGrandPlanNetwork
+from rate.NormalizedMixtureNeuron import STREAM_TOPDOWN
+
+'''
+Sensory-loss experiment on the retinotopic grand-plan architecture, mirroring
+the validated two-region sensory-loss protocol but on the Sulfaro-normalized V1.
+
+Two loss modes:
+  "scotoma"  a contiguous patch of visual columns is silenced (audio intact,
+             the rest of the visual field intact);
+  "blind"    every visual column is silenced (full visual loss, audio intact).
+
+Four epochs (matching the two-region experiment):
+  1 baseline          visual + audio on, serotonin baseline
+  2 loss              masked visual columns -> 0 (stay 0 thereafter)
+  3 serotonin + plast serotonin raised, plasticity ON for the cross-modal
+                      audio -> V1 remapping synapses
+  4 return            serotonin back to baseline, plasticity OFF
+
+A no-plasticity control (plasticityEnabled=False) runs the identical protocol
+with plasticity never switched on, isolating the causal role of the remapping
+synapses in any recovery.
+
+Readout population: because V1 receptive fields overlap (topographicRadius), a
+silenced column at the edge of the lesion still receives visual current from its
+intact neighbors, so it is not truly deprived. The primary readout is therefore
+taken over FULLY-DEPRIVED columns -- silenced columns whose entire receptive
+field (all columns within topographicRadius) is also silenced, so no visual
+current leaks in. For full blindness every column is fully deprived; for a
+scotoma it is the lesion interior. Intact = columns still receiving their own
+visual input.
+
+Recorded per step (means over the FULLY-DEPRIVED columns' V1 pyramidals unless noted):
+  rateDeprived       V1 firing rate in fully-deprived columns
+  rateIntact         V1 firing rate in intact columns
+  audioCurrent       raw cross-modal (audio) drive into deprived-column V1
+  visualCurrent      raw visual drive into deprived-column V1 (-> ~0 after loss)
+  topDownCurrent     raw top-down (Category feedback) drive into deprived V1
+  remapWeight        mean audio -> V1 remapping-synapse weight
+
+In Sulfaro terms, a silenced column loses its bottom-up visual drive and becomes
+top-down dominated (the hallucination-prone regime); serotonin-gated potentiation
+of the cross-modal audio synapses restores an ascending (bottom-up) drive, and
+the question is whether that restoration persists into epoch 4.
+'''
+
+
+class RetinotopicGrandPlanSimulation:
+    def __init__(self, params, stimulus, inputSet, mode="scotoma",
+                 plasticityEnabled=True):
+        self.params = params
+        self.tau = params["tau"]
+        self.epochDurationMs = params["epochDurationMs"]
+        self.warmupMs = params.get("warmupMs", 300.0)
+        self.mode = mode
+        self.plasticityEnabled = plasticityEnabled
+
+        self.network = RetinotopicGrandPlanNetwork(self.tau, params)
+        self.inputSet = inputSet
+        self.stimulus = stimulus
+        self.remapping = self.network.audioRemappingAxons()   # AudioInput -> V1pyr
+
+        # Present the stimulus (held fixed across epochs; only the mask changes).
+        self.network.setVisualRates(inputSet.visualRates(stimulus))
+        self.network.setAudioRates(inputSet.audioRates(stimulus))
+
+        # Column masks: silenced (visual set to 0) and fully-deprived (silenced
+        # with the entire receptive field silenced, so no visual leaks in).
+        self.silencedColumns = self._buildMask(mode)
+        self.deprivedColumns = self._deprivedColumns(self.silencedColumns)
+        self.deprivedCells, self.intactCells = self._partitionV1Cells()
+
+        # Records
+        self.epochBoundaries = []
+        self.rateDeprived = []
+        self.rateIntact = []
+        self.audioCurrent = []
+        self.visualCurrent = []
+        self.topDownCurrent = []
+        self.remapWeight = []
+
+        self._audioPop = self.network.populations["AudioInput"]
+        self._visualPop = self.network.populations["VisualInput"]
+
+    # ---- setup helpers ----
+
+    def _buildMask(self, mode):
+        G = self.network.G
+        nCols = self.network.nCols
+        mask = [False] * nCols
+        if mode == "blind":
+            return [True] * nCols
+        # scotoma: silence a central patch large enough (ceil(2G/3)) that its
+        # interior columns are fully deprived even with RF radius 1.
+        h = max(1, -(-2 * G // 3))
+        x0 = (G - h) // 2
+        y0 = (G - h) // 2
+        for y in range(y0, y0 + h):
+            for x in range(x0, x0 + h):
+                mask[y * G + x] = True
+        return mask
+
+    def _deprivedColumns(self, silenced):
+        # A silenced column is fully deprived iff every column within the V1
+        # receptive-field radius is also silenced (no visual current leaks in).
+        G = self.network.G
+        radius = self.params["topographicRadius"]
+        deprived = [False] * self.network.nCols
+        for col in range(self.network.nCols):
+            if not silenced[col]:
+                continue
+            cx, cy = col % G, col // G
+            allSilenced = True
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    nx, ny = cx + dx, cy + dy
+                    if 0 <= nx < G and 0 <= ny < G:
+                        if not silenced[ny * G + nx]:
+                            allSilenced = False
+                            break
+                if not allSilenced:
+                    break
+            deprived[col] = allSilenced
+        return deprived
+
+    def _partitionV1Cells(self):
+        cpc = self.network.cellsPerColumn
+        deprived, intact = [], []
+        for cell in self.network.populations["V1pyr"].cells:
+            col = cell._idx // cpc
+            if self.deprivedColumns[col]:
+                deprived.append(cell)
+            elif not self.silencedColumns[col]:
+                intact.append(cell)
+            # silenced-but-not-fully-deprived (penumbra) columns are excluded
+            # from both readouts.
+        return deprived, intact
+
+    # ---- recording ----
+
+    def _record(self):
+        sc = self.deprivedCells
+        self.rateDeprived.append(np.mean([c.rate for c in sc]) if sc else float("nan"))
+        self.rateIntact.append(np.mean([c.rate for c in self.intactCells]) if self.intactCells else float("nan"))
+        self.audioCurrent.append(np.mean([c.lastSourceCurrent.get(self._audioPop, 0.0) for c in sc]) if sc else float("nan"))
+        self.visualCurrent.append(np.mean([c.lastSourceCurrent.get(self._visualPop, 0.0) for c in sc]) if sc else float("nan"))
+        self.topDownCurrent.append(np.mean([c.lastStreamCurrent[STREAM_TOPDOWN] for c in sc]) if sc else float("nan"))
+        self.remapWeight.append(float(np.mean([a.weight for a in self.remapping])) if self.remapping else float("nan"))
+
+    # ---- run ----
+
+    def _stepFor(self, durationMs, record=True):
+        for _ in np.arange(0.0, durationMs, self.tau):
+            self.network.step()
+            if record:
+                self._record()
+
+    def _resetRecords(self):
+        self.epochBoundaries = []
+        for key in ("rateDeprived", "rateIntact", "audioCurrent",
+                    "visualCurrent", "topDownCurrent", "remapWeight"):
+            setattr(self, key, [])
+
+    def _endEpoch(self, epoch):
+        self.epochBoundaries.append(self.epochDurationMs * epoch)
+
+    def warmup(self):
+        self._stepFor(self.warmupMs, record=False)
+        self._resetRecords()
+
+    def epoch1_baseline(self):
+        self._stepFor(self.epochDurationMs)
+        self._endEpoch(1)
+
+    def epoch2_loss(self):
+        self.network.setVisualScotoma(self.silencedColumns)
+        self._stepFor(self.epochDurationMs)
+        self._endEpoch(2)
+
+    def epoch3_serotonin_plasticity(self):
+        self.network.setSerotonin(self.params["remapSerotoninLevel"])
+        if self.plasticityEnabled:
+            for axon in self.remapping:
+                axon.enablePlasticity(self.params["gamma_p"], self.params["gamma_d"],
+                                      self.params["plasticityThreshold"],
+                                      ceilingFactor=self.params["plasticityCeilingFactor"])
+        self._stepFor(self.epochDurationMs)
+        for axon in self.remapping:
+            axon.disablePlasticity()
+        self._endEpoch(3)
+
+    def epoch4_return(self):
+        self.network.setSerotonin(self.params["serotoninLevel"])
+        self._stepFor(self.epochDurationMs)
+        self._endEpoch(4)
+
+    def run(self):
+        self.warmup()
+        self.epoch1_baseline()
+        self.epoch2_loss()
+        self.epoch3_serotonin_plasticity()
+        self.epoch4_return()
+        return self

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -247,6 +247,11 @@ class RetinotopicGrandPlanSimulation:
             self.network.setV1SomaticSerotonin(p["v1SerotoninDeprived"], self.deprivedCells)
             self.network.setV1BottomUpGain(p["v1BottomUpGainDeprived"], self.deprivedCells)
             self.network.setCrossModalAxonalSerotonin(p["crossModalSerotoninLevel"], self.plasticAxons)
+            # Non-serotonergic driver of the transient hyperactivity (intrinsic
+            # excitability homeostasis); required for the cortex to fire enough
+            # for the Hebbian remapping to bootstrap. Removed at return.
+            self.network.setDeprivedIntrinsicDrive(p.get("intrinsicExcitabilityDrive", 0.0),
+                                                   self.deprivedCells)
             plasticThreshold = p["plasticityThresholdDeprived"]
         else:
             self.network.setSerotonin(p["remapSerotoninLevel"])
@@ -264,10 +269,12 @@ class RetinotopicGrandPlanSimulation:
     def epoch4_return(self):
         p = self.params
         if p.get("realistic5HT", False):
-            # Restore the deprived region and its cross-modal input to baseline.
+            # Restore the deprived region and its cross-modal input to baseline;
+            # the intrinsic-excitability drive relaxes as remapping restores input.
             self.network.setV1SomaticSerotonin(p["serotoninLevel"], self.deprivedCells)
             self.network.setV1BottomUpGain(1.0, self.deprivedCells)
             self.network.setCrossModalAxonalSerotonin(p["serotoninLevel"], self.plasticAxons)
+            self.network.setDeprivedIntrinsicDrive(0.0, self.deprivedCells)
         else:
             self.network.setSerotonin(p["serotoninLevel"])
         self._stepFor(self.epochDurationMs)

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -105,6 +105,7 @@ class RetinotopicGrandPlanSimulation:
         self.artClass = []
         self.artReject = []
         self.artMatch = []
+        self.artCategory = []     # winning ART category index per step (None on reject)
         self.trueLabel = stimulus.label
 
         self._audioPop = self.network.populations["AudioInput"]
@@ -179,6 +180,7 @@ class RetinotopicGrandPlanSimulation:
             self.artReject.append(bool(d["reject"]))
             self.artClass.append(REJECT if d["reject"] else int(d["label"]))
             self.artMatch.append(float(d["match"]))
+            self.artCategory.append(None if d["reject"] else int(d["category"]))
 
     # ---- run ----
 
@@ -192,7 +194,7 @@ class RetinotopicGrandPlanSimulation:
         self.epochBoundaries = []
         for key in ("rateDeprived", "rateIntact", "audioCurrent",
                     "visualCurrent", "topDownCurrent", "remapWeight",
-                    "artClass", "artReject", "artMatch"):
+                    "artClass", "artReject", "artMatch", "artCategory"):
             setattr(self, key, [])
 
     def v1ColumnMap(self):

--- a/rate/RetinotopicGrandPlanSimulation.py
+++ b/rate/RetinotopicGrandPlanSimulation.py
@@ -229,7 +229,13 @@ class RetinotopicGrandPlanSimulation:
         deficit = 0.0 if not self.A_set else max(0.0, (self.A_set - A) / self.A_set)
         target = min(1.0, p.get("homeostaticGain", 1.4) * deficit)
         dt = self._ctrlEvery * self.tau
-        self.homeostaticH += (dt / p["homeostaticTau"]) * (target - self.homeostaticH)
+        # Asymmetric time constant: ramp fast (tau), relax slow (tauRelax). The
+        # slow relaxation makes intrinsic/scaling changes persist after activity
+        # recovers, so the loop is underdamped and produces the transient
+        # hyperactivity overshoot rather than a critically-damped monotonic return.
+        tau_ctrl = p["homeostaticTau"] if target >= self.homeostaticH \
+            else p.get("homeostaticTauRelax", p["homeostaticTau"])
+        self.homeostaticH += (dt / tau_ctrl) * (target - self.homeostaticH)
         self.homeostaticH = min(1.0, max(0.0, self.homeostaticH))
         self._applyEmergentResponses(self.homeostaticH)
 

--- a/rate/RetinotopicV31Simulation.py
+++ b/rate/RetinotopicV31Simulation.py
@@ -1,0 +1,190 @@
+import numpy as np
+
+from rate.RetinotopicGrandPlanSimulation import RetinotopicGrandPlanSimulation
+from rate.Classifiers import make_classifier
+from rate.ARTClassifier import REJECT
+
+'''
+v3.1 experiment: emergent option-B network + homeostatic controller, but driven
+by a SHUFFLED SEQUENCE of multi-class images paired with loosely-correlated
+discrete sound clips, and read out by a SWITCHABLE, slowly-learning unsupervised
+classifier (FUZZY_ART / FUZZY_ARTMAP / KNN).
+
+The scientific target is the emergence of NEW, audio-driven categories in the
+classifier once audio comes to dominate the deprived cortex -- and the transient
+hallucination (stale visual categories forced onto absent input) that precedes
+it. The classifier is a pure READOUT here (no top-down feedback into V1); see
+V3.1_Plan.md.
+
+Two decoupled learning rates: remapLearningRate (audio->V1 plasticity, drives
+recovery) and classifierLearningRate (slow category learning). Plasticity is on
+from the sighted baseline so cross-modal drive can build; the classifier learns
+slowly at every presentation.
+
+Per-presentation records (one entry per image presentation, not per step):
+  timeMs, assignedCluster, mappedLabel, trueClass, clipId, confidence,
+  rateDeprived, rateIntact, homeostaticDrive, remapWeight, audioCurrent,
+  visualCurrent, nClusters
+plus classifier snapshots every snapshotEvery presentations.
+'''
+
+from rate.NormalizedMixtureNeuron import STREAM_TOPDOWN
+
+
+class RetinotopicV31Simulation(RetinotopicGrandPlanSimulation):
+    def __init__(self, params, presenter, mode="blind", plasticityEnabled=True, seed=0):
+        p = dict(params)
+        p["useART"] = False                      # classifier managed here, not in the network
+        p["emergent5HT"] = True                  # reuse the emergent controller
+        super().__init__(p, presenter.inputSet.stimuli[0], presenter.inputSet,
+                         mode=mode, plasticityEnabled=plasticityEnabled)
+        self.presenter = presenter
+        self.seed = seed
+
+        self.presentationMs = float(p.get("presentationMs", 100.0))
+        self.baselineMs = float(p.get("baselineMs", 2000.0))
+        self.postLossMs = float(p.get("postLossMs", 20000.0))
+        self.snapshotEvery = int(p.get("snapshotEvery", 20))
+        self._aEMA = None
+        self._aEMAtau = float(p.get("homeostaticActivityTau", 500.0))
+
+        # Switchable classifier over the V1 feature (length nCols).
+        self.classifier = make_classifier(
+            kind=p.get("classifierType", "FUZZY_ART"),
+            dim=self.network.nCols,
+            learningRate=p.get("classifierLearningRate", 0.05),
+            vigilance=p.get("artVigilance", 0.75),
+            activityFloor=p.get("artActivityFloor", 0.05),
+            knnDistanceVigilance=p.get("knnDistanceVigilance", 0.30),
+            seed=seed)
+
+        # Records (per presentation).
+        self.recTime = []
+        self.assignedCluster = []
+        self.mappedLabel = []
+        self.trueClass = []
+        self.clipIdRec = []
+        self.confidence = []
+        self.rateDeprivedSeq = []
+        self.rateIntactSeq = []
+        self.homeostaticDriveSeq = []
+        self.remapWeightSeq = []
+        self.audioCurrentSeq = []
+        self.visualCurrentSeq = []
+        self.nClustersSeq = []
+        self.snapshots = []          # (presentationIndex, snapshot dict)
+        self.lossPresentationIndex = None
+        self.clipClassAssociation = None
+
+    # --- controller reads an EMA of deprived activity (sequence smooths noise) ---
+    def _deprivedActivity(self):
+        inst = float(np.mean([c.rate for c in self.deprivedCells])) if self.deprivedCells else 0.0
+        if self._aEMA is None:
+            self._aEMA = inst
+        else:
+            dt = self._ctrlEvery * self.tau
+            self._aEMA += (dt / self._aEMAtau) * (inst - self._aEMA)
+        return self._aEMA
+
+    # --- classifier pretraining on clean-V1 features (vision + canonical clip) ---
+    def _pretrainClassifier(self, settleMs):
+        steps = int(round(settleMs / self.tau))
+        X, y = [], []
+        for st in self.presenter.inputSet.stimuli:
+            self.network.resetActivity()
+            self.network.setVisualRates(self.presenter.inputSet.visualRates(st))
+            clip = self.presenter.bank.canonical_clip(st.label)
+            self.network.setAudioRates(self.presenter.audioRates(clip))
+            for _ in range(steps):
+                self.network.step()
+            X.append(self.network.v1FeatureVector())
+            y.append(st.label)
+        self.classifier.pretrain(X, y)
+
+    # --- one image presentation ---
+    def _present(self, stimIndex, clipId, tMs, deprived, learn):
+        self.network.setVisualRates(self.presenter.visualRates(stimIndex))
+        if deprived:
+            self.network.setVisualScotoma(self.silencedColumns)   # re-mask after setVisualRates
+        self.network.setAudioRates(self.presenter.audioRates(clipId))
+        steps = int(round(self.presentationMs / self.tau))
+        for _ in range(steps):
+            if self._controllerActive:
+                self._ctrlCount += 1
+                if self._ctrlCount % self._ctrlEvery == 0:
+                    self._controllerStep()
+            self.network.step()
+
+        feat = self.network.v1FeatureVector()
+        cluster, label, conf = self.classifier.observe(feat)
+        if learn:
+            self.classifier.learn(feat)
+
+        sc = self.deprivedCells
+        self.recTime.append(tMs)
+        self.assignedCluster.append(cluster)
+        self.mappedLabel.append(label)
+        self.trueClass.append(self.presenter.true_label(stimIndex))
+        self.clipIdRec.append(clipId)
+        self.confidence.append(conf)
+        self.rateDeprivedSeq.append(float(np.mean([c.rate for c in sc])) if sc else float("nan"))
+        self.rateIntactSeq.append(float(np.mean([c.rate for c in self.intactCells])) if self.intactCells else float("nan"))
+        self.homeostaticDriveSeq.append(self.homeostaticH)
+        self.remapWeightSeq.append(float(np.mean([a.weight for a in self.plasticAxons])) if self.plasticAxons else float("nan"))
+        self.audioCurrentSeq.append(float(np.mean([c.lastSourceCurrent.get(self._audioPop, 0.0) for c in sc])) if sc else float("nan"))
+        self.visualCurrentSeq.append(float(np.mean([c.lastStreamCurrent[STREAM_TOPDOWN] for c in sc])) if sc else float("nan"))
+        self.nClustersSeq.append(self.classifier.n_clusters)
+
+    def run(self):
+        p = self.params
+        # Turn off the heavy per-cell history (unused; memory).
+        self.network.setCellHistoryRecording(False)
+
+        # Pretrain the classifier on clean V1, then warm up the network.
+        self._pretrainClassifier(p.get("artPretrainSettleMs", 200.0))
+        self.network.resetActivity()
+        self._stepFor(self.warmupMs, record=False)
+
+        # Plasticity ON from the sighted baseline (cross-modal drive can build).
+        if self.plasticityEnabled:
+            for a in self.plasticAxons:
+                a.enablePlasticity(p["gamma_p"], p["gamma_d"], p["plasticityThreshold"],
+                                   ceilingFactor=p["plasticityCeilingFactor"])
+
+        nBaseline = int(round(self.baselineMs / self.presentationMs))
+        nPost = int(round(self.postLossMs / self.presentationMs))
+        nTotal = nBaseline + nPost
+        seq = self.presenter.generate_sequence(nTotal, seed=self.seed)
+        self.clipClassAssociation = self.presenter.measuredClipClassAssociation(seq)
+
+        t = 0.0
+        # ---- baseline (sighted) ----
+        for i in range(nBaseline):
+            si, clip = seq[i]
+            self._present(si, clip, t, deprived=False, learn=True)
+            if i % self.snapshotEvery == 0:
+                self.snapshots.append((i, self.classifier.snapshot()))
+            t += self.presentationMs
+        # set-point from baseline deprived activity
+        base = [r for r in self.rateDeprivedSeq if not np.isnan(r)]
+        self.A_set = float(np.mean(base[len(base) // 2:])) if base else None
+
+        # ---- impose loss; activate controller ----
+        self.network.setVisualScotoma(self.silencedColumns)
+        self._controllerActive = True
+        self.lossPresentationIndex = nBaseline
+        self._lossTimeMs = t
+
+        # ---- post-loss (deprivation -> recovery -> long stable window) ----
+        for i in range(nBaseline, nTotal):
+            si, clip = seq[i]
+            self._present(si, clip, t, deprived=True, learn=True)
+            if i % self.snapshotEvery == 0:
+                self.snapshots.append((i, self.classifier.snapshot()))
+            t += self.presentationMs
+
+        if self.plasticityEnabled:
+            for a in self.plasticAxons:
+                a.disablePlasticity()
+        self.snapshots.append((nTotal - 1, self.classifier.snapshot()))
+        return self

--- a/rate/StructuredInput.py
+++ b/rate/StructuredInput.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 from scipy.ndimage import sobel
 
@@ -85,7 +87,17 @@ class StructuredInputSet:
         self.minRateHz = minRateHz
         self.maxRateHz = maxRateHz
         self.rng = np.random.RandomState(seed)
-        self.stimuli = [self._make_stimulus(c) for c in range(classCount)]
+        self.stimuli = [self._make_stimulus(label, grid)
+                        for (label, grid) in self._prototype_grids()]
+
+    # ---- prototype source (override for real images) ----
+
+    def _prototype_grids(self):
+        # (label, raw greyscale G x G grid in [0,1]) pairs. The base class
+        # synthesizes class-distinct patterns; ImageFolderInputSet overrides this
+        # to load real labeled images. Edge detection and the r=0.25 audio
+        # construction happen downstream in _make_stimulus, identically for both.
+        return [(c, self._class_image(c)) for c in range(self.classCount)]
 
     # ---- stimulus construction ----
 
@@ -128,8 +140,8 @@ class StructuredInputSet:
         a_std = r * z_v + np.sqrt(1.0 - r * r) * e_perp
         return _minmax01(a_std)
 
-    def _make_stimulus(self, label):
-        edges = self._edge_detect(self._class_image(label))
+    def _make_stimulus(self, label, rawImage):
+        edges = self._edge_detect(rawImage)
         audio = self._correlated_audio(edges.reshape(-1))
         return StructuredAVStimulus(label, edges, audio)
 
@@ -153,3 +165,65 @@ class StructuredInputSet:
         if v_pooled.std() == 0 or stimulus.audio.std() == 0:
             return float("nan")
         return float(np.corrcoef(v_pooled, stimulus.audio)[0, 1])
+
+
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tif", ".tiff", ".webp")
+
+
+def load_image_grid(path, gridSize):
+    """Load an image file as a greyscale G x G grid in [0, 1].
+
+    Uses Pillow (already required by matplotlib). The image is converted to
+    luminance and resized to the retinotopic grid; edge detection and the
+    r=0.25 audio pairing are applied downstream, identically to synthetic input.
+    """
+    from PIL import Image
+    img = Image.open(path).convert("L").resize((gridSize, gridSize))
+    return np.asarray(img, dtype=float) / 255.0
+
+
+class ImageFolderInputSet(StructuredInputSet):
+    """StructuredInputSet sourced from a folder of labeled images.
+
+    Expects `root` to contain one subfolder per class (e.g. person/, horse/);
+    subfolder names sorted alphabetically become the class labels 0..K-1. Up to
+    imagesPerClass images are loaded per class (deterministically, sorted by
+    filename). Everything downstream -- Sobel edge detection, the exact r=0.25
+    audio pairing, rate conversion -- is inherited unchanged, so the real-image
+    stimuli are drop-in compatible with the retinotopic experiment and the
+    self-check's correlation guarantee.
+
+    self.stimuli is a flat list ordered by (class, image); self.classNames maps
+    label index -> folder name. The sensory-loss experiment uses stimuli[0].
+    """
+
+    def __init__(self, root, gridSize=10, audioBins=20, imagesPerClass=1,
+                 minRateHz=0.0, maxRateHz=30.0, seed=0):
+        self.root = root
+        self.imagesPerClass = imagesPerClass
+        self.classNames, self._loadedGrids = self._loadGrids(root, gridSize, imagesPerClass)
+        super().__init__(gridSize=gridSize, audioBins=audioBins,
+                         classCount=len(self.classNames),
+                         minRateHz=minRateHz, maxRateHz=maxRateHz, seed=seed)
+
+    def _loadGrids(self, root, gridSize, imagesPerClass):
+        classDirs = sorted(d for d in os.listdir(root)
+                           if os.path.isdir(os.path.join(root, d)))
+        if not classDirs:
+            raise ValueError("No class subfolders found under %r" % root)
+        classNames = []
+        grids = []   # list of (label, grid01)
+        for label, name in enumerate(classDirs):
+            classNames.append(name)
+            d = os.path.join(root, name)
+            files = sorted(f for f in os.listdir(d)
+                           if f.lower().endswith(IMAGE_EXTENSIONS))
+            if not files:
+                raise ValueError("No images in class folder %r" % d)
+            for f in files[:imagesPerClass]:
+                grids.append((label, load_image_grid(os.path.join(d, f), gridSize)))
+        return classNames, grids
+
+    def _prototype_grids(self):
+        return self._loadedGrids
+

--- a/rate/StructuredInput.py
+++ b/rate/StructuredInput.py
@@ -1,0 +1,155 @@
+import numpy as np
+from scipy.ndimage import sobel
+
+'''
+Structured audio-visual input for the retinotopic grand-plan architecture.
+
+Two design points from the grand-plan spec are honored here:
+
+  1. Visual input is a still image run through EDGE DETECTION, reduced to a
+     G x G retinotopic grid of values in [0, 1], carrying a class LABEL. This
+     module synthesizes simple, class-distinct greyscale patterns and applies a
+     Sobel edge filter so the pipeline is self-contained and runnable, but the
+     same interface (grid + label) accepts real labeled images (e.g. the
+     person/horse folders) by swapping _class_image().
+
+  2. Audio is only r = 0.25 correlated with the visual input. The audio vector
+     (A tonotopic bins) is constructed so the SAMPLE Pearson correlation between
+     the audio and the pooled visual pattern is exactly r = 0.25, via
+
+         a = r * z_v + sqrt(1 - r^2) * e_perp
+
+     where z_v is the standardized pooled-visual vector and e_perp is Gaussian
+     noise Gram-Schmidt-orthogonalized against z_v and restandardized. Because
+     z_v and e_perp are sample-orthogonal unit-variance vectors, corr(a, z_v) =
+     r for THIS finite sample, not merely in expectation (the plain shared-latent
+     formula a = r*z_v + sqrt(1-r^2)*e leaves sampling error of order 1/sqrt(A)
+     around r, large for A ~ 20 bins). Min-max rescaling to [0, 1] afterward is a
+     positive affine map and preserves Pearson correlation, so the target r holds.
+
+Rates are obtained by scaling the [0, 1] values to a firing-rate range
+(minRateHz .. maxRateHz), matching the rate model's input-lambda convention.
+'''
+
+TARGET_AV_CORRELATION = 0.25
+
+
+def _standardize(x):
+    x = np.asarray(x, dtype=float)
+    sd = x.std()
+    if sd == 0.0:
+        return np.zeros_like(x)
+    return (x - x.mean()) / sd
+
+
+def _minmax01(x):
+    x = np.asarray(x, dtype=float)
+    lo, hi = x.min(), x.max()
+    if hi - lo == 0.0:
+        return np.zeros_like(x)
+    return (x - lo) / (hi - lo)
+
+
+def _pool_to_length(vec, length):
+    # Average-pool a 1-D vector to the requested length (block means). Used to
+    # bring the G*G visual vector down to the A-bin audio dimensionality before
+    # correlating, the audio analogue of feedforward pooling.
+    vec = np.asarray(vec, dtype=float)
+    if length >= len(vec):
+        # simple repeat-interpolate up (rare; A is usually < G*G)
+        idx = np.linspace(0, len(vec) - 1, length).round().astype(int)
+        return vec[idx]
+    edges = np.linspace(0, len(vec), length + 1).astype(int)
+    return np.array([vec[edges[i]:edges[i + 1]].mean() for i in range(length)])
+
+
+class StructuredAVStimulus:
+    def __init__(self, label, visualGrid, audioVector):
+        self.label = label                 # class index (int)
+        self.visualGrid = visualGrid       # (G, G) float array in [0, 1]
+        self.visual = visualGrid.reshape(-1)   # flattened, length G*G
+        self.audio = audioVector           # length A, float in [0, 1]
+
+
+class StructuredInputSet:
+    '''
+    A tiny labeled audio-visual dataset. classCount distinct visual prototypes
+    (edge-detected), each paired with an r=0.25-correlated audio vector.
+    '''
+
+    def __init__(self, gridSize=10, audioBins=20, classCount=2,
+                 minRateHz=0.0, maxRateHz=30.0, seed=0):
+        self.gridSize = gridSize
+        self.audioBins = audioBins
+        self.classCount = classCount
+        self.minRateHz = minRateHz
+        self.maxRateHz = maxRateHz
+        self.rng = np.random.RandomState(seed)
+        self.stimuli = [self._make_stimulus(c) for c in range(classCount)]
+
+    # ---- stimulus construction ----
+
+    def _class_image(self, label):
+        # Synthesize a class-distinct greyscale image (G x G). Class 0 is
+        # dominated by vertical structure, class 1 by horizontal structure,
+        # further classes by diagonal bands -- enough for edge detection to
+        # produce visibly different maps. Swap this for real image loading to
+        # use the person/horse dataset.
+        g = self.gridSize
+        yy, xx = np.mgrid[0:g, 0:g]
+        if label % 3 == 0:
+            img = np.sin(2 * np.pi * xx / max(2, g / 3.0))
+        elif label % 3 == 1:
+            img = np.sin(2 * np.pi * yy / max(2, g / 3.0))
+        else:
+            img = np.sin(2 * np.pi * (xx + yy) / max(2, g / 3.0))
+        img = _minmax01(img)
+        return img
+
+    def _edge_detect(self, img):
+        gx = sobel(img, axis=0, mode="reflect")
+        gy = sobel(img, axis=1, mode="reflect")
+        mag = np.hypot(gx, gy)
+        return _minmax01(mag).reshape(self.gridSize, self.gridSize)
+
+    def _correlated_audio(self, visualFlat):
+        r = TARGET_AV_CORRELATION
+        v_pooled = _pool_to_length(visualFlat, self.audioBins)
+        z_v = _standardize(v_pooled)
+        if not np.any(z_v):
+            # degenerate (constant) pooled visual: correlation undefined, return noise
+            return _minmax01(self.rng.randn(self.audioBins))
+        e = self.rng.randn(self.audioBins)
+        # Gram-Schmidt: remove the z_v component so e_perp is sample-orthogonal
+        # to z_v (dot product 0), then restandardize. Orthogonality survives the
+        # mean-subtraction in _standardize because z_v sums to 0.
+        e = e - (e @ z_v) / (z_v @ z_v) * z_v
+        e_perp = _standardize(e)
+        a_std = r * z_v + np.sqrt(1.0 - r * r) * e_perp
+        return _minmax01(a_std)
+
+    def _make_stimulus(self, label):
+        edges = self._edge_detect(self._class_image(label))
+        audio = self._correlated_audio(edges.reshape(-1))
+        return StructuredAVStimulus(label, edges, audio)
+
+    # ---- rate conversion ----
+
+    def _to_rate(self, unit01):
+        return self.minRateHz + (self.maxRateHz - self.minRateHz) * np.asarray(unit01, dtype=float)
+
+    def visualRates(self, stimulus):
+        return self._to_rate(stimulus.visual)
+
+    def audioRates(self, stimulus):
+        return self._to_rate(stimulus.audio)
+
+    # ---- verification helper ----
+
+    def measuredAVCorrelation(self, stimulus):
+        # Empirical Pearson r between the audio vector and the pooled visual,
+        # for the r=0.25 self-check.
+        v_pooled = _pool_to_length(stimulus.visual, self.audioBins)
+        if v_pooled.std() == 0 or stimulus.audio.std() == 0:
+            return float("nan")
+        return float(np.corrcoef(v_pooled, stimulus.audio)[0, 1])

--- a/rate/StructuredInput.py
+++ b/rate/StructuredInput.py
@@ -182,6 +182,110 @@ def load_image_grid(path, gridSize):
     return np.asarray(img, dtype=float) / 255.0
 
 
+class SoundBank:
+    """A fixed bank of `size` distinct sound clips (tonotopic vectors in [0,1]).
+
+    Each clip is a fixed random pattern (seeded). Class c has a canonical clip
+    (index c mod size); the presenter plays it with probability matchProb, else a
+    uniformly random clip, so clip-ID is loosely correlated with class-ID. The
+    bank may be larger than the class count, so some clips carry structure not
+    tied to any visual class -- material for novel auditory categories.
+    """
+
+    def __init__(self, size, audioBins, seed=0):
+        self.size = int(size)
+        self.audioBins = int(audioBins)
+        rng = np.random.RandomState(seed)
+        self.clips = [_minmax01(rng.randn(audioBins)) for _ in range(self.size)]
+
+    def canonical_clip(self, classLabel):
+        return classLabel % self.size
+
+    def clip_vector(self, clipId):
+        return self.clips[clipId]
+
+
+class SequencePresenter:
+    """Wraps an InputSet (synthetic or ImageFolderInputSet) and adds (a) a fixed
+    sound bank whose clip-ID is loosely correlated with image class-ID, and (b) a
+    seeded, reproducible, randomly-shuffled presentation sequence.
+
+    A presentation is a (stimulusIndex, clipId) pair. Visual rates come from the
+    wrapped set; audio rates come from the chosen clip. Correlation strength is
+    set by matchProb (prob the canonical clip for the image's class is played).
+    """
+
+    def __init__(self, inputSet, soundBankSize=None, matchProb=0.25, seed=0):
+        self.inputSet = inputSet
+        self.audioBins = inputSet.audioBins
+        self.classNames = getattr(inputSet, "classNames", None)
+        self.classCount = inputSet.classCount
+        self.matchProb = float(matchProb)
+        if soundBankSize is None:
+            soundBankSize = self.classCount
+        self.bank = SoundBank(soundBankSize, self.audioBins, seed=seed + 101)
+
+    # ---- sequence ----
+
+    def generate_sequence(self, nPresentations, seed=0):
+        """List of (stimulusIndex, clipId), length nPresentations. Class exposure
+        is balanced (tiled permutations of the stimulus list); the clip for each
+        presentation is the canonical clip w.p. matchProb else a uniform-random
+        bank clip. Reproducible from seed."""
+        rng = np.random.RandomState(seed)
+        nStim = len(self.inputSet.stimuli)
+        order = []
+        while len(order) < nPresentations:
+            perm = list(rng.permutation(nStim))
+            order.extend(perm)
+        order = order[:nPresentations]
+        seq = []
+        for si in order:
+            label = self.inputSet.stimuli[si].label
+            if rng.rand() < self.matchProb:
+                clip = self.bank.canonical_clip(label)
+            else:
+                clip = int(rng.randint(self.bank.size))
+            seq.append((si, clip))
+        return seq
+
+    # ---- rate conversion ----
+
+    def visualRates(self, stimulusIndex):
+        st = self.inputSet.stimuli[stimulusIndex]
+        return self.inputSet.visualRates(st)
+
+    def audioRates(self, clipId):
+        return self.inputSet._to_rate(self.bank.clip_vector(clipId))
+
+    def true_label(self, stimulusIndex):
+        return self.inputSet.stimuli[stimulusIndex].label
+
+    # ---- verification ----
+
+    def measuredClipClassAssociation(self, sequence):
+        """Cramer's V between clip-ID and class-ID over a sequence, the categorical
+        analogue of the old r = 0.25 audio-visual correlation (0 = independent,
+        1 = deterministic). Use to calibrate matchProb."""
+        labels = [self.inputSet.stimuli[si].label for si, _ in sequence]
+        clips = [c for _, c in sequence]
+        K = self.classCount
+        M = self.bank.size
+        table = np.zeros((K, M))
+        for lab, cl in zip(labels, clips):
+            table[lab, cl] += 1
+        n = table.sum()
+        if n == 0:
+            return float("nan")
+        row = table.sum(1, keepdims=True)
+        col = table.sum(0, keepdims=True)
+        expected = row @ col / n
+        with np.errstate(divide="ignore", invalid="ignore"):
+            chi2 = np.nansum(np.where(expected > 0, (table - expected) ** 2 / expected, 0.0))
+        denom = n * (min(K, M) - 1)
+        return float(np.sqrt(chi2 / denom)) if denom > 0 else float("nan")
+
+
 class ImageFolderInputSet(StructuredInputSet):
     """StructuredInputSet sourced from a folder of labeled images.
 

--- a/rate/V31RunOne.py
+++ b/rate/V31RunOne.py
@@ -1,0 +1,103 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import argparse
+import pickle
+import random
+
+import numpy as np
+
+from rate.RetinotopicGrandPlanParams import buildGrandPlanParams
+from rate.RetinotopicV31Simulation import RetinotopicV31Simulation
+from rate.StructuredInput import StructuredInputSet, ImageFolderInputSet, SequencePresenter
+
+'''
+Run ONE v3.1 simulation (one mode x one plasticity condition x one classifier)
+and pickle its per-presentation records + classifier snapshots. The two learning
+rates are set here at run time: --remap-lr (audio->V1 plasticity, gamma_p) and
+--classifier-lr (slow category learning). Classifier is switchable via
+--classifier {FUZZY_ART,FUZZY_ARTMAP,KNN}. See V3.1_Plan.md.
+
+If --images is omitted, a synthetic >=3-class set is used (no image files needed)
+so the pipeline is runnable/testable stand-alone.
+'''
+
+FIELDS = ["recTime", "assignedCluster", "mappedLabel", "trueClass", "clipIdRec",
+          "confidence", "rateDeprivedSeq", "rateIntactSeq", "homeostaticDriveSeq",
+          "remapWeightSeq", "audioCurrentSeq", "visualCurrentSeq", "nClustersSeq",
+          "snapshots", "lossPresentationIndex", "A_set", "clipClassAssociation",
+          "presentationMs", "baselineMs", "postLossMs"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--images", default=None, help="folder of per-class subfolders; omit for synthetic")
+    ap.add_argument("--mode", default="blind", choices=["blind", "scotoma"])
+    ap.add_argument("--plasticity", type=int, default=1)
+    ap.add_argument("--classifier", default="FUZZY_ART", choices=["FUZZY_ART", "FUZZY_ARTMAP", "KNN"])
+    ap.add_argument("--classifier-lr", type=float, default=0.05)
+    ap.add_argument("--remap-lr", type=float, default=None, help="gamma_p; default = params/10")
+    ap.add_argument("--grid", type=int, default=10)
+    ap.add_argument("--cpc", type=int, default=8)
+    ap.add_argument("--classes", type=int, default=3, help="synthetic only")
+    ap.add_argument("--images-per-class", type=int, default=3)
+    ap.add_argument("--presentation-ms", type=float, default=100.0)
+    ap.add_argument("--baseline-ms", type=float, default=2000.0)
+    ap.add_argument("--postloss-ms", type=float, default=20000.0)
+    ap.add_argument("--sound-bank-size", type=int, default=None)
+    ap.add_argument("--match-prob", type=float, default=0.25)
+    ap.add_argument("--snapshot-every", type=int, default=20)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    random.seed(args.seed); np.random.seed(args.seed)
+
+    if args.images:
+        data = ImageFolderInputSet(args.images, gridSize=args.grid, audioBins=20,
+                                   imagesPerClass=args.images_per_class, seed=args.seed)
+        nClasses = len(data.classNames)
+    else:
+        data = StructuredInputSet(gridSize=args.grid, audioBins=20,
+                                  classCount=args.classes, seed=args.seed)
+        nClasses = args.classes
+
+    p = buildGrandPlanParams(gridSize=args.grid, cellsPerColumn=args.cpc, categoryCount=nClasses)
+    p["emergent5HT"] = True
+    p["classifierType"] = args.classifier
+    p["classifierLearningRate"] = args.classifier_lr
+    p["gamma_p"] = args.remap_lr if args.remap_lr is not None else p["gamma_p"] / 10.0
+    p["presentationMs"] = args.presentation_ms
+    p["baselineMs"] = args.baseline_ms
+    p["postLossMs"] = args.postloss_ms
+    p["snapshotEvery"] = args.snapshot_every
+    p["soundClassMatchProb"] = args.match_prob
+
+    presenter = SequencePresenter(data, soundBankSize=args.sound_bank_size,
+                                  matchProb=args.match_prob, seed=args.seed)
+
+    sim = RetinotopicV31Simulation(p, presenter, mode=args.mode,
+                                   plasticityEnabled=bool(args.plasticity), seed=args.seed)
+    sim.run()
+
+    blob = {f: getattr(sim, f) for f in FIELDS}
+    blob["params"] = p
+    blob["classNames"] = getattr(data, "classNames", [str(i) for i in range(nClasses)])
+    blob["mode"] = args.mode
+    blob["plasticity"] = bool(args.plasticity)
+    blob["classifier"] = args.classifier
+    blob["soundBankSize"] = presenter.bank.size
+    with open(args.out, "wb") as fh:
+        pickle.dump(blob, fh)
+    n = len(sim.assignedCluster)
+    print("wrote %s (classifier=%s mode=%s plast=%s): %d presentations, "
+          "final n_clusters=%d, clip-class assoc=%.3f"
+          % (args.out, args.classifier, args.mode, bool(args.plasticity), n,
+             sim.nClustersSeq[-1] if sim.nClustersSeq else -1,
+             sim.clipClassAssociation if sim.clipClassAssociation is not None else float("nan")))
+
+
+if __name__ == "__main__":
+    main()

--- a/rate/fit_transfer_functions.py
+++ b/rate/fit_transfer_functions.py
@@ -1,0 +1,100 @@
+"""
+Derive the rate-model transfer functions F(I) = k * [I - theta]_+^n for each
+cortical cell type, by measuring the steady-state f-I curve of the
+corresponding Izhikevich cell and fitting a threshold power law.
+
+IMPORTANT: this uses the Izhikevich-2007 form
+    C dv/dt = k(v - v_r)(v - v_t) - u + I
+      du/dt = a( b(v - v_r) - u )
+    reset when v >= v_peak:  v <- c,  u <- u + d
+which is the form the network's cell parameters (C, k, v_r, v_t and the
+a/b/c/d ranges) actually belong to. The repo's spiking model/Neuron.py instead
+integrates the older Izhikevich-2003 form (0.04 v^2 + 5 v + 140 - u + I) with
+these 2007 parameters, a mismatch that makes FS/LTS cells fire spontaneously at
+rest and inflates rates into the thousands (see docs in the rate/ package).
+We do NOT modify Neuron.py (the spiking model is preserved as the "Last Spiking"
+checkpoint); this standalone measurement only produces the fitted transfer
+coefficients baked into CellTypes.py.
+
+Run directly to re-derive and print the coefficients:
+    python3 rate/fit_transfer_functions.py
+"""
+import numpy as np
+from scipy.optimize import curve_fit
+
+# Izhikevich-2007 parameters per cortical cell type, matching the values used
+# in network/RetinotopicAVNetwork.py and network/SerotoninAVNetwork.py.
+CELL_PARAMS = {
+    "Pyramidal": {"C": 100, "k": 3, "v_r": -60, "v_t": -50, "v_peak": 50,
+                  "a": 0.01, "b": 5, "c": -60, "d": 400},
+    "FS": {"C": 20, "k": 1, "v_r": -55, "v_t": -40, "v_peak": 25,
+           "a": 0.15, "b": 8, "c": -55, "d": 200},
+    "LTS": {"C": 100, "k": 1, "v_r": -56, "v_t": -42, "v_peak": 40,
+            "a": 0.03, "b": 8, "c": -50, "d": 200},
+}
+
+TAU = 0.1            # ms, matches the network integration step
+T_TOTAL = 2000.0     # ms per current level
+T_DISCARD = 1000.0   # ms of leading transient discarded before counting spikes
+# Rates at/above this are contaminated by fixed-timestep inter-spike-interval
+# quantization (spike-every-few-steps staircase); excluded from the fit.
+QUANT_CEILING = 2000.0
+
+
+def _derivs(v, u, p, I):
+    dv = (p["k"] * (v - p["v_r"]) * (v - p["v_t"]) - u + I) / p["C"]
+    du = p["a"] * (p["b"] * (v - p["v_r"]) - u)
+    return dv, du
+
+
+def measure_rate(p, I):
+    """Steady-state firing rate (spikes/sec) of one Izhikevich-2007 cell at constant I."""
+    v, u, t = p["v_r"], 0.0, 0.0
+    spikes = 0
+    h = TAU
+    for _ in range(int(T_TOTAL / TAU)):
+        t += h
+        k1v, k1u = _derivs(v, u, p, I)
+        k2v, k2u = _derivs(v + 0.5 * h * k1v, u + 0.5 * h * k1u, p, I)
+        k3v, k3u = _derivs(v + 0.5 * h * k2v, u + 0.5 * h * k2u, p, I)
+        k4v, k4u = _derivs(v + h * k3v, u + h * k3u, p, I)
+        v += (h / 6.0) * (k1v + 2 * k2v + 2 * k3v + k4v)
+        u += (h / 6.0) * (k1u + 2 * k2u + 2 * k3u + k4u)
+        if v >= p["v_peak"]:
+            v, u = p["c"], u + p["d"]
+            if t >= T_DISCARD:
+                spikes += 1
+    return spikes / ((T_TOTAL - T_DISCARD) / 1000.0)
+
+
+def power_law(I, k, theta, n):
+    return k * np.clip(I - theta, 0, None) ** n
+
+
+def fit_cell_type(name, currents=None):
+    if currents is None:
+        currents = np.linspace(0, 1400, 57)
+    currents = np.asarray(currents, dtype=float)
+    rates = np.array([measure_rate(CELL_PARAMS[name], I) for I in currents])
+
+    clean = rates < QUANT_CEILING
+    fit_I, fit_r = currents[clean], rates[clean]
+    positive = fit_r > 0
+    theta0 = fit_I[positive][0]
+    span = max(fit_I[positive][-1] - theta0, 1.0)
+    p0 = [fit_r.max() / (span ** 0.5), theta0, 0.5]
+    popt, _ = curve_fit(power_law, fit_I, fit_r, p0=p0, maxfev=40000,
+                        bounds=([0, -np.inf, 0.2], [np.inf, np.inf, 4.0]))
+    resid = fit_r - power_law(fit_I, *popt)
+    ss_res = float(np.sum(resid ** 2))
+    ss_tot = float(np.sum((fit_r - fit_r.mean()) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return {"k": float(popt[0]), "theta": float(popt[1]), "n": float(popt[2]),
+            "r2": r2, "currents": currents, "rates": rates}
+
+
+if __name__ == "__main__":
+    for name in CELL_PARAMS:
+        fit = fit_cell_type(name)
+        print("%-10s k=%.5g  theta=%.5g  n=%.5g  R^2=%.4f"
+              % (name, fit["k"], fit["theta"], fit["n"], fit["r2"]))

--- a/rate/plotting.py
+++ b/rate/plotting.py
@@ -1,0 +1,93 @@
+import os
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+'''
+Shared plotting helpers for the rate two-region experiments (sensory-loss and
+pharmacological). The plot functions are epoch-count-agnostic (they read
+sim.epochBoundaries), so they work for both the 4-epoch and 3-epoch protocols.
+'''
+
+
+def smooth(series, win_ms, tau):
+    # Boxcar smoothing with edge-extension (mode="nearest"), NOT zero-padding.
+    # np.convolve(mode="same") zero-pads the ends, which drags the first/last
+    # ~half-window of samples toward zero and creates a spurious ramp at t=0 in
+    # otherwise-flat traces; uniform_filter1d(mode="nearest") holds the edge
+    # value instead.
+    from scipy.ndimage import uniform_filter1d
+    n = max(1, int(win_ms / tau))
+    s = np.asarray(series, dtype=float)
+    if len(s) < n:
+        return s
+    return uniform_filter1d(s, size=n, mode="nearest")
+
+
+def epoch_lines(ax, boundaries):
+    for b in boundaries[:-1]:
+        ax.axvline(b, color="0.6", ls="--", lw=1)
+
+
+def plot_rates(sim, outdir, tau, prefix, title):
+    pops = [("InputA", "Sensory Input (S_alpha)"),
+            ("pyramidalsA", "Pyramidal (P_alpha)"),
+            ("fastSpikingsA", "Fast Spiking (F_alpha)"),
+            ("lowThresholdsA", "Low-Threshold Spiking (L_alpha)")]
+    fig, axes = plt.subplots(4, 1, figsize=(8, 10), sharex=True)
+    for ax, (pop, subtitle) in zip(axes, pops):
+        rec = sim.network.populations[pop].rateRecord
+        t = np.arange(len(rec)) * tau
+        ax.plot(t, smooth(rec, 20.0, tau), color="C0")
+        ax.set_title(subtitle, loc="left", fontsize=10)
+        ax.set_ylabel("Rate (Hz)")
+        epoch_lines(ax, sim.epochBoundaries)
+    axes[-1].set_xlabel("Time (ms)")
+    fig.suptitle(title)
+    fig.tight_layout()
+    path = os.path.join(outdir, prefix + "_rates.png")
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    return path
+
+
+def plot_influence(sim, outdir, tau, prefix, title):
+    pa = sim.network.populations["pyramidalsA"]
+    inputA = sim.network.populations["InputA"]
+    inputB = sim.network.populations["InputB"]
+    # Leave-one-out ablation influence of each input on P_alpha's commanded rate.
+    infA = np.array(pa.ablationInfluence[inputA])
+    infB = np.array(pa.ablationInfluence[inputB])
+    t = np.arange(len(infA)) * tau
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, -smooth(infA, 20.0, tau), color="C3", label="Input alpha (own, plotted negative)")
+    ax.plot(t, smooth(infB, 20.0, tau), color="C0", label="Input beta (cross-modal, positive)")
+    ax.axhline(0, color="0.7", lw=0.8)
+    epoch_lines(ax, sim.epochBoundaries)
+    ax.set_xlabel("Time (ms)")
+    ax.set_ylabel("Ablation influence on P_alpha rate (Hz)")
+    ax.set_title(title)
+    ax.legend(fontsize="small")
+    fig.tight_layout()
+    path = os.path.join(outdir, prefix + "_influence.png")
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    return path
+
+
+def plot_weights(sim, outdir, tau, prefix, title):
+    w = sim.weightHistory
+    t = np.arange(len(w)) * tau
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, w, color="C2")
+    epoch_lines(ax, sim.epochBoundaries)
+    ax.set_xlabel("Time (ms)")
+    ax.set_ylabel("Mean remapping weight (S_B -> P_A)")
+    ax.set_title(title)
+    fig.tight_layout()
+    path = os.path.join(outdir, prefix + "_weights.png")
+    fig.savefig(path, dpi=110)
+    plt.close(fig)
+    return path

--- a/rate/plotting_grandplan.py
+++ b/rate/plotting_grandplan.py
@@ -98,7 +98,43 @@ def plot_experiment(sim, control, outdir, title_prefix):
         if p is not None:
             paths.append(p)
 
+    # --- Panel 6: emergent homeostatic controller (only when it ran) ---
+    hd = getattr(sim, "homeostaticDrive", None)
+    if hd and np.any(np.asarray(hd, dtype=float) > 1e-6):
+        p = plot_homeostatic(sim, outdir, title_prefix)
+        if p is not None:
+            paths.append(p)
+
     return paths
+
+
+def plot_homeostatic(sim, outdir, title_prefix):
+    # Emergent controller: deprived firing (left axis) and the latent drive h
+    # (right axis) over time, showing that the drop -> hyperactivity -> settle
+    # trajectory and the response ramp/relaxation emerge from the activity deficit
+    # -- the only imposed event is the loss.
+    tau = sim.tau
+    rate = np.asarray(sim.rateDeprived, dtype=float)
+    h = np.asarray(sim.homeostaticDrive, dtype=float)
+    t = np.arange(len(rate)) * tau
+    fig, axL = plt.subplots(figsize=(9, 4))
+    axL.plot(t, smooth(rate, 40.0, tau), color="C3", label="deprived V1 rate")
+    if sim.A_set is not None:
+        axL.axhline(sim.A_set, color="C3", ls=":", lw=1, label="baseline set-point")
+    axL.set_xlabel("Time (ms)"); axL.set_ylabel("V1 firing rate (Hz)", color="C3")
+    axL.tick_params(axis="y", labelcolor="C3")
+    axR = axL.twinx()
+    axR.plot(t, h, color="C0", label="homeostatic drive h")
+    axR.set_ylabel("controller drive h", color="C0"); axR.set_ylim(0, 1.05)
+    axR.tick_params(axis="y", labelcolor="C0")
+    epoch_lines(axL, sim.epochBoundaries)
+    axL.set_title("%s: emergent homeostatic response (only the loss is imposed)" % title_prefix)
+    l1, la = axL.get_legend_handles_labels(); l2, lb = axR.get_legend_handles_labels()
+    axL.legend(l1 + l2, la + lb, fontsize="small", loc="upper right")
+    fig.tight_layout()
+    path = os.path.join(outdir, "homeostatic.png")
+    fig.savefig(path, dpi=110); plt.close(fig)
+    return path
 
 
 def plot_art(sim, outdir, title_prefix):

--- a/rate/plotting_grandplan.py
+++ b/rate/plotting_grandplan.py
@@ -1,0 +1,99 @@
+import os
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from rate.plotting import smooth, epoch_lines
+
+'''
+Plotting for the retinotopic grand-plan sensory-loss experiment. Each figure
+overlays the plasticity condition against the no-plasticity control so the
+causal role of the cross-modal remapping synapses is visible directly.
+
+Panels:
+  1. V1 firing rate in fully-deprived vs intact columns.
+  2. Stream currents into deprived-column V1: visual (bottom-up, lost),
+     audio (cross-modal, the remapping readout), top-down (Category feedback).
+  3. Mean audio -> V1 remapping-synapse weight.
+'''
+
+EPOCH_LABELS = ["baseline", "loss", "5HT + plasticity", "return"]
+
+
+def _time(sim):
+    return np.arange(len(sim.remapWeight)) * sim.tau
+
+
+def _epoch_labels(ax, sim):
+    epoch_lines(ax, sim.epochBoundaries)
+    for i, b in enumerate([0] + list(sim.epochBoundaries[:-1])):
+        if i < len(EPOCH_LABELS):
+            ax.text(b + 5, ax.get_ylim()[1], EPOCH_LABELS[i], fontsize=7,
+                    va="top", ha="left", color="0.4")
+
+
+def plot_experiment(sim, control, outdir, title_prefix):
+    tau = sim.tau
+    t = _time(sim)
+    win = 20.0
+    os.makedirs(outdir, exist_ok=True)
+    paths = []
+
+    # --- Panel 1: rates ---
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, smooth(sim.rateDeprived, win, tau), color="C3", label="deprived V1 (plasticity)")
+    ax.plot(t, smooth(sim.rateIntact, win, tau), color="C0", label="intact V1 (plasticity)")
+    if control is not None:
+        ax.plot(t, smooth(control.rateDeprived, win, tau), color="C3", ls="--",
+                label="deprived V1 (control, no plasticity)")
+    ax.set_xlabel("Time (ms)"); ax.set_ylabel("V1 firing rate (Hz)")
+    ax.set_title("%s: V1 firing rate, deprived vs intact columns" % title_prefix)
+    _epoch_labels(ax, sim); ax.legend(fontsize="small")
+    fig.tight_layout()
+    p = os.path.join(outdir, "rates.png"); fig.savefig(p, dpi=110); plt.close(fig); paths.append(p)
+
+    # --- Panel 2: stream currents into deprived V1 ---
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, smooth(sim.visualCurrent, win, tau), color="C0", label="visual bottom-up (lost at loss)")
+    ax.plot(t, smooth(sim.audioCurrent, win, tau), color="C2", label="audio cross-modal (remapping)")
+    ax.plot(t, smooth(sim.topDownCurrent, win, tau), color="C1", label="top-down (Category feedback)")
+    if control is not None:
+        ax.plot(t, smooth(control.audioCurrent, win, tau), color="C2", ls="--",
+                label="audio cross-modal (control)")
+    ax.set_xlabel("Time (ms)"); ax.set_ylabel("Raw stream current into deprived V1")
+    ax.set_title("%s: input streams to deprived-column V1" % title_prefix)
+    _epoch_labels(ax, sim); ax.legend(fontsize="small")
+    fig.tight_layout()
+    p = os.path.join(outdir, "streams.png"); fig.savefig(p, dpi=110); plt.close(fig); paths.append(p)
+
+    # --- Panel 3: remapping weight ---
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(t, sim.remapWeight, color="C2", label="plasticity")
+    if control is not None:
+        ax.plot(t, control.remapWeight, color="0.5", ls="--", label="control (no plasticity)")
+    ax.set_xlabel("Time (ms)"); ax.set_ylabel("Mean audio -> V1 weight")
+    ax.set_title("%s: cross-modal remapping-synapse weight" % title_prefix)
+    _epoch_labels(ax, sim); ax.legend(fontsize="small")
+    fig.tight_layout()
+    p = os.path.join(outdir, "remap_weight.png"); fig.savefig(p, dpi=110); plt.close(fig); paths.append(p)
+
+    return paths
+
+
+def epoch_means(sim):
+    # Convenience: per-epoch means of the key series for a compact text summary.
+    tau = sim.tau
+    dur = sim.epochDurationMs
+    out = {}
+    for name in ("rateDeprived", "rateIntact", "audioCurrent", "visualCurrent",
+                 "topDownCurrent", "remapWeight"):
+        arr = np.asarray(getattr(sim, name), dtype=float)
+        vals = []
+        for e in range(4):
+            s = int(e * dur / tau); en = int((e + 1) * dur / tau)
+            seg = arr[s:en]
+            vals.append(float(np.nanmean(seg)) if len(seg) else float("nan"))
+        out[name] = vals
+    return out

--- a/rate/plotting_grandplan.py
+++ b/rate/plotting_grandplan.py
@@ -87,7 +87,55 @@ def plot_experiment(sim, control, outdir, title_prefix):
     fig.tight_layout()
     p = os.path.join(outdir, "remap_weight.png"); fig.savefig(p, dpi=110); plt.close(fig); paths.append(p)
 
+    # --- Panel 4: retinotopic V1 maps (edge input + per-epoch V1 activity) ---
+    p = plot_maps(sim, outdir, title_prefix)
+    if p is not None:
+        paths.append(p)
+
     return paths
+
+
+def plot_maps(sim, outdir, title_prefix):
+    # Edge-detected input + per-epoch V1 column-rate maps, with the lesion
+    # outlined, so the deprived region visibly darkens at loss and partially
+    # re-lights after cross-modal remapping.
+    if not sim.v1MapsByEpoch:
+        return None
+    epochs = sorted(sim.v1MapsByEpoch)
+    maps = [sim.v1MapsByEpoch[e] for e in epochs]
+    vmax = max(1e-6, max(float(np.nanmax(m)) for m in maps))
+    n = len(epochs) + 1
+    fig, axes = plt.subplots(1, n, figsize=(3.2 * n, 3.4))
+    axes[0].imshow(sim.inputGrid, cmap="magma")
+    axes[0].set_title("edge input (V1 bottom-up)", fontsize=9)
+    for ax, e, m in zip(axes[1:], epochs, maps):
+        im = ax.imshow(m, cmap="viridis", vmin=0, vmax=vmax)
+        ax.set_title("V1 rate: %s" % EPOCH_LABELS[e - 1], fontsize=9)
+        _outline_lesion(ax, sim.silencedMap)
+    for ax in axes:
+        ax.set_xticks([]); ax.set_yticks([])
+    fig.colorbar(im, ax=axes.tolist(), fraction=0.02, pad=0.01, label="Hz")
+    fig.suptitle("%s: retinotopic V1 activity across epochs (lesion outlined)" % title_prefix)
+    path = os.path.join(outdir, "v1_maps.png")
+    fig.savefig(path, dpi=110); plt.close(fig)
+    return path
+
+
+def _outline_lesion(ax, silencedMap):
+    # Draw a thin outline around the silenced (lesioned) columns.
+    G = silencedMap.shape[0]
+    for y in range(G):
+        for x in range(G):
+            if not silencedMap[y, x]:
+                continue
+            if y == 0 or not silencedMap[y - 1, x]:
+                ax.plot([x - 0.5, x + 0.5], [y - 0.5, y - 0.5], color="red", lw=1.2)
+            if y == G - 1 or not silencedMap[y + 1, x]:
+                ax.plot([x - 0.5, x + 0.5], [y + 0.5, y + 0.5], color="red", lw=1.2)
+            if x == 0 or not silencedMap[y, x - 1]:
+                ax.plot([x - 0.5, x - 0.5], [y - 0.5, y + 0.5], color="red", lw=1.2)
+            if x == G - 1 or not silencedMap[y, x + 1]:
+                ax.plot([x + 0.5, x + 0.5], [y - 0.5, y + 0.5], color="red", lw=1.2)
 
 
 def epoch_means(sim):

--- a/rate/plotting_grandplan.py
+++ b/rate/plotting_grandplan.py
@@ -92,7 +92,52 @@ def plot_experiment(sim, control, outdir, title_prefix):
     if p is not None:
         paths.append(p)
 
+    # --- Panel 5: ART classifier readout (only when the ART secondary area ran) ---
+    if getattr(sim, "artMatch", None):
+        p = plot_art(sim, outdir, title_prefix)
+        if p is not None:
+            paths.append(p)
+
     return paths
+
+
+def plot_art(sim, outdir, title_prefix):
+    # ART secondary-area readout over the experiment: the one-hot decision
+    # (class vs reject) and the match/confidence, so hallucination (confident
+    # classification without veridical input) and recovery are visible.
+    tau = sim.tau
+    cls = np.asarray(sim.artClass, dtype=float)     # class label, or -1 (reject)
+    match = np.asarray(sim.artMatch, dtype=float)
+    t = np.arange(len(cls)) * tau
+    classNames = getattr(sim.inputSet, "classNames", None)
+    true_lbl = getattr(sim, "trueLabel", None)
+
+    fig, (axd, axm) = plt.subplots(2, 1, figsize=(9, 5), sharex=True,
+                                   gridspec_kw={"height_ratios": [1, 1.4]})
+    # Decision strip: reject at -1, classes at 0,1,...
+    axd.plot(t, cls, color="0.3", lw=1.0, drawstyle="steps-post")
+    axd.scatter(t[::50], cls[::50], c=["0.6" if v < 0 else ("C2" if v == true_lbl else "C3")
+                                       for v in cls[::50]], s=8, zorder=3)
+    if true_lbl is not None:
+        axd.axhline(true_lbl, color="C2", ls=":", lw=1, label="true class")
+    ncls = (len(classNames) if classNames else int(np.nanmax(cls)) + 1)
+    axd.set_yticks([-1] + list(range(ncls)))
+    axd.set_yticklabels(["reject"] + (classNames if classNames else [str(i) for i in range(ncls)]))
+    axd.set_ylabel("ART decision"); axd.set_ylim(-1.5, ncls - 0.5)
+    epoch_lines(axd, sim.epochBoundaries); axd.legend(fontsize="small", loc="upper right")
+    axd.set_title("%s: ART secondary-area readout (classify / reject)" % title_prefix)
+
+    axm.plot(t, match, color="C0", label="match / confidence")
+    vig = sim.params.get("artVigilance", None)
+    if vig is not None:
+        axm.axhline(vig, color="C3", ls="--", lw=1, label="vigilance (reject below)")
+    axm.set_ylabel("ART match"); axm.set_xlabel("Time (ms)"); axm.set_ylim(0, 1)
+    epoch_lines(axm, sim.epochBoundaries); axm.legend(fontsize="small", loc="lower right")
+
+    fig.tight_layout()
+    path = os.path.join(outdir, "art_readout.png")
+    fig.savefig(path, dpi=110); plt.close(fig)
+    return path
 
 
 def plot_maps(sim, outdir, title_prefix):

--- a/rate/plotting_grandplan.py
+++ b/rate/plotting_grandplan.py
@@ -44,12 +44,20 @@ def plot_experiment(sim, control, outdir, title_prefix):
     # --- Panel 1: rates ---
     fig, ax = plt.subplots(figsize=(9, 4))
     ax.plot(t, smooth(sim.rateDeprived, win, tau), color="C3", label="deprived V1 (plasticity)")
-    ax.plot(t, smooth(sim.rateIntact, win, tau), color="C0", label="intact V1 (plasticity)")
+    # Intact columns only exist when the lesion spares part of the field (a
+    # scotoma). Under full blindness every column is deprived, so the intact
+    # series is all-NaN -- skip it (and its legend entry) rather than draw a
+    # phantom line.
+    intact = np.asarray(sim.rateIntact, dtype=float)
+    has_intact = np.any(np.isfinite(intact))
+    if has_intact:
+        ax.plot(t, smooth(sim.rateIntact, win, tau), color="C0", label="intact V1 (plasticity)")
     if control is not None:
         ax.plot(t, smooth(control.rateDeprived, win, tau), color="C3", ls="--",
-                label="deprived V1 (control, no plasticity)")
+                label="deprived V1 (control; == plasticity until 5HT epoch)")
     ax.set_xlabel("Time (ms)"); ax.set_ylabel("V1 firing rate (Hz)")
-    ax.set_title("%s: V1 firing rate, deprived vs intact columns" % title_prefix)
+    title_tail = "deprived vs intact columns" if has_intact else "deprived columns (no intact columns under full blindness)"
+    ax.set_title("%s: V1 firing rate, %s" % (title_prefix, title_tail))
     _epoch_labels(ax, sim); ax.legend(fontsize="small")
     fig.tight_layout()
     p = os.path.join(outdir, "rates.png"); fig.savefig(p, dpi=110); plt.close(fig); paths.append(p)

--- a/rate/plotting_v31.py
+++ b/rate/plotting_v31.py
@@ -1,0 +1,124 @@
+import os
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+'''
+Plots + metrics for the v3.1 sequence experiment. The classifier is a moving
+target (slow continuous learning), so everything is measured over time:
+
+  n_clusters(t)          do new categories appear?
+  ARI vs visual class    alignment of the assignment to the ORIGINAL visual
+  ARI vs sound-clip ID    labels (should fall) vs the audio structure (should
+                          rise) as audio comes to dominate.
+  hallucination rate     deprived-phase presentations mapped to a stale
+                          WRONG-visual-class cluster.
+  rate + h               to relate emergence to the fading intrinsic drive.
+'''
+
+
+def adjusted_rand_index(a, b):
+    a = np.asarray(a); b = np.asarray(b)
+    ua = {v: i for i, v in enumerate(np.unique(a))}
+    ub = {v: i for i, v in enumerate(np.unique(b))}
+    n = len(a)
+    if n == 0:
+        return float("nan")
+    cont = np.zeros((len(ua), len(ub)))
+    for x, y in zip(a, b):
+        cont[ua[x], ub[y]] += 1
+    def comb2(x):
+        return x * (x - 1) / 2.0
+    sum_ij = comb2(cont).sum()
+    sum_i = comb2(cont.sum(1)).sum()
+    sum_j = comb2(cont.sum(0)).sum()
+    total = comb2(n)
+    expected = sum_i * sum_j / total if total else 0.0
+    maxi = 0.5 * (sum_i + sum_j)
+    denom = maxi - expected
+    if denom == 0:
+        return 1.0
+    return float((sum_ij - expected) / denom)
+
+
+def _windows(n, win, step):
+    i = 0
+    while i + win <= n:
+        yield i, i + win
+        i += step
+
+
+def compute_series(blob, win=40, step=10):
+    cluster = np.asarray(blob["assignedCluster"])
+    mapped = np.asarray(blob["mappedLabel"])
+    truec = np.asarray(blob["trueClass"])
+    clip = np.asarray(blob["clipIdRec"])
+    t = np.asarray(blob["recTime"], dtype=float)
+    loss_i = blob["lossPresentationIndex"]
+    out = {"t_mid": [], "ari_visual": [], "ari_clip": [], "halluc": []}
+    for lo, hi in _windows(len(cluster), win, step):
+        cl = cluster[lo:hi]; mp = mapped[lo:hi]; tc = truec[lo:hi]; cp = clip[lo:hi]
+        out["t_mid"].append(float(np.mean(t[lo:hi])))
+        out["ari_visual"].append(adjusted_rand_index(cl, tc))
+        out["ari_clip"].append(adjusted_rand_index(cl, cp))
+        # hallucination: mapped to a real class that is wrong (exclude REJECT)
+        real = mp >= 0
+        wrong = real & (mp != tc)
+        out["halluc"].append(float(np.sum(wrong)) / max(1, np.sum(real | ~real)))
+    for k in out:
+        out[k] = np.asarray(out[k], dtype=float)
+    out["loss_t"] = t[loss_i] if (loss_i is not None and loss_i < len(t)) else None
+    return out
+
+
+def plot_v31(blob, outdir, title_prefix):
+    os.makedirs(outdir, exist_ok=True)
+    paths = []
+    s = compute_series(blob)
+    t = np.asarray(blob["recTime"], dtype=float)
+    loss_t = s["loss_t"]
+
+    def _vline(ax):
+        if loss_t is not None:
+            ax.axvline(loss_t, color="0.4", ls="--", lw=1)
+            ax.text(loss_t, ax.get_ylim()[1], " loss", fontsize=7, va="top", color="0.4")
+
+    # 1. cluster count + rate + h
+    fig, axL = plt.subplots(figsize=(9, 4))
+    axL.plot(t, blob["nClustersSeq"], color="C4", label="n_clusters")
+    axL.set_xlabel("Time (ms)"); axL.set_ylabel("n clusters", color="C4")
+    axL.tick_params(axis="y", labelcolor="C4")
+    axR = axL.twinx()
+    axR.plot(t, blob["rateDeprivedSeq"], color="C3", lw=1, alpha=0.8, label="deprived rate")
+    axR.plot(t, np.asarray(blob["homeostaticDriveSeq"]) * (np.nanmax(blob["rateDeprivedSeq"]) or 1),
+             color="C0", lw=1, ls=":", label="h (scaled)")
+    axR.set_ylabel("deprived rate (Hz) / h", color="C3"); axR.tick_params(axis="y", labelcolor="C3")
+    _vline(axL)
+    axL.set_title("%s: cluster count vs deprived activity" % title_prefix)
+    l1, la = axL.get_legend_handles_labels(); l2, lb = axR.get_legend_handles_labels()
+    axL.legend(l1 + l2, la + lb, fontsize="small", loc="upper left")
+    fig.tight_layout(); pth = os.path.join(outdir, "clusters.png")
+    fig.savefig(pth, dpi=110); plt.close(fig); paths.append(pth)
+
+    # 2. ARI vs visual class and vs clip id
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(s["t_mid"], s["ari_visual"], color="C1", label="ARI vs visual class (old labels)")
+    ax.plot(s["t_mid"], s["ari_clip"], color="C2", label="ARI vs sound-clip ID (audio structure)")
+    ax.set_xlabel("Time (ms)"); ax.set_ylabel("Adjusted Rand Index"); ax.set_ylim(-0.1, 1.05)
+    _vline(ax)
+    ax.set_title("%s: what the clusters track over time" % title_prefix)
+    ax.legend(fontsize="small"); fig.tight_layout()
+    pth = os.path.join(outdir, "ari.png"); fig.savefig(pth, dpi=110); plt.close(fig); paths.append(pth)
+
+    # 3. hallucination rate
+    fig, ax = plt.subplots(figsize=(9, 4))
+    ax.plot(s["t_mid"], s["halluc"], color="C3", label="hallucination rate (wrong visual class)")
+    ax.set_xlabel("Time (ms)"); ax.set_ylabel("fraction of presentations"); ax.set_ylim(0, 1.0)
+    _vline(ax)
+    ax.set_title("%s: hallucination (stale wrong-class readout)" % title_prefix)
+    ax.legend(fontsize="small"); fig.tight_layout()
+    pth = os.path.join(outdir, "hallucination.png"); fig.savefig(pth, dpi=110); plt.close(fig); paths.append(pth)
+
+    return paths, s

--- a/rate/results/V3.1_Plan.md
+++ b/rate/results/V3.1_Plan.md
@@ -1,0 +1,117 @@
+# Version 3.1 — working spec (supersedes V3_PLAN.md)
+
+Goal: show **new, auditory-only categories emerging** in a downstream classifier
+once audio comes to dominate a deprived visual cortex — and the transient
+hallucination (stale visual categories forced onto absent input) that precedes
+the emergence. Built on the emergent option-B network + homeostatic controller.
+
+This supersedes the earlier one-hot/"blank-class" framing in V3_PLAN.md: the
+resolution is NOT recovery of the original visual classes, it is the
+self-organisation of *new* categories driven by the cross-modal audio input.
+
+## Design changes vs v3.0/ART runs
+
+1. **Image sequence, not a single held stimulus.** A seeded, reproducible,
+   randomly shuffled sequence of images is presented over the trial, each for
+   `presentationMs`. ≥3 classes (images supplied by the user, one subfolder per
+   class; `ImageFolderInputSet` already handles arbitrary class counts).
+
+2. **Discrete sound clips, loosely correlated to image class.** A fixed bank of
+   `soundBankSize` distinct sound clips (each a fixed random tonotopic vector).
+   Each class has a canonical clip; at each presentation the canonical clip is
+   played with probability `soundClassMatchProb`, otherwise a uniformly random
+   clip from the whole bank. Correlation is now **clip-ID ↔ class-ID**, kept
+   loose (target association ~ the old r = 0.25). `soundBankSize` may exceed the
+   class count so some clips carry structure not tied to any visual class —
+   material for genuinely novel auditory categories. A measured association
+   helper is provided as the analogue of `measuredAVCorrelation`.
+
+3. **Unsupervised classifier replacing ARTMAP, switchable.** `classifierType ∈
+   {FUZZY_ART, FUZZY_ARTMAP, KNN}` selected at runtime:
+   - **FUZZY_ART** — unsupervised fuzzy ART (choice/match/vigilance, slow
+     recode; commits new categories via vigilance). The scientific default.
+   - **FUZZY_ARTMAP** — supervised at pretrain (match tracking → labelled map),
+     then slow *unsupervised* recode during the trial (no labels available in a
+     deprivation trial). Comparison backend; shows a labelled map drifting.
+   - **KNN** — online nearest-prototype / k-means-style clusterer: prototypes
+     start from pretrain, the nearest prototype drifts toward each input by the
+     learning rate, and an input far from all prototypes (distance-vigilance)
+     spawns a new one. Nearest prototype → cluster; its pretrain-majority class →
+     label. Comparison backend.
+   All three expose the same interface (`pretrain`, `observe`, `learn`,
+   `n_clusters`, cluster→class map) and can **spawn new clusters and drift**, so
+   emergence of new categories is possible in each.
+
+4. **Pretrain, then learn slowly at all points.** The classifier is pretrained on
+   clean-V1 representations of the labelled images (as ART was). During the trial
+   it learns continuously but slowly (unsupervised), so baseline groupings stay
+   stable, the early high-drive transient cements almost nothing, and new
+   audio-driven categories accrete gradually in the late, stable, audio-dominated
+   window.
+
+5. **Two decoupled, runtime-set learning rates (global params).**
+   - `remapLearningRate` — the audio→V1 remapping plasticity (`gamma_p`); drives
+     activity recovery and lets the homeostatic drive `h` (and intrinsic drive)
+     relax. Fast enough to recover within the trial.
+   - `classifierLearningRate` — the classifier's own slow category learning
+     (ART `beta` / KNN centroid step). Slow enough to be inert during the
+     transient, non-trivial over the long final window.
+   Both are set by the user at run time; they are independent.
+
+6. **Final window sized to the classifier rate.** Because slow category formation
+   needs room, the post-recovery stable stretch is a first-class parameter
+   (`finalWindowMs` / extra stable epochs). Size it from `classifierLearningRate`,
+   not the old default.
+
+7. **Serotonin / receptors unchanged (already literature-correct).** Bulk 5HT in
+   the deprived cortex is not raised (slightly lowered); the response is raised
+   intrinsic excitability + 5HT2A-consistent gain + raised 5HT on the cross-modal
+   axons + lowered plasticity threshold, all scaled by the emergent controller's
+   `h`. No change needed for v3.1; documented so the sign story stays explicit
+   (receptor remodeling / balance shift, not more transmitter).
+
+## Classifier as a readout (scope note)
+
+In this build the classifier is a **pure readout** — it observes the V1 feature
+each step and learns from it, but does NOT feed top-down back into V1. Closing
+the classifier→V1 loop (with a deliberately set feedback gain, per the latching
+caveat) is a follow-on; kept out here so the emergence measurement is clean and
+the feedback-stability question is separated. A `classifierTopDown` flag is
+reserved (default off).
+
+## Controller under a sequence
+
+`A_set` is the mean deprived rate over the sequence during baseline (many
+images), and the controller reads an **EMA of deprived activity** rather than an
+instantaneous value, so per-image fluctuation in the shuffled sequence does not
+inject noise into `h`. Everything else (asymmetric ramp/relax, option-B
+overshoot) is unchanged.
+
+## Metrics (define up front — the readout is a moving target)
+
+Recorded per presentation and snapshotted periodically (`snapshotEvery`):
+- **n_clusters** over time — do new categories appear?
+- **ARI vs visual class** and **ARI vs sound-clip ID** over time — alignment to
+  the old visual labels should fall while alignment to audio structure rises.
+- **hallucination rate** — fraction of deprived-phase presentations assigned to a
+  stale wrong-visual-class cluster.
+- **cluster-onset / stabilisation times** — when new clusters first appear and
+  when the assignment distribution stops changing (a "resolution time").
+- rate trajectory + `h` (as before), to relate emergence to the fading intrinsic
+  drive.
+
+## Staged build (validate each before stacking)
+
+1. Seeded shuffled multi-class image sequence.
+2. Sound-clip bank + tunable clip-class association.
+3. Switchable unsupervised classifier + slow learning + readout/metrics.
+4. Plasticity-from-baseline + controller EMA + sized final window.
+5. Serotonin/receptor refinement (already in place; revisit citations).
+
+## Open knobs the user sets at run time
+
+`classifierType`, `classifierLearningRate`, `remapLearningRate`, `presentationMs`,
+sequence length, `soundBankSize`, `soundClassMatchProb`, `finalWindowMs`,
+`snapshotEvery`, grid/epochs. The single most load-bearing for whether distinct
+auditory categories emerge is the **audio-drive vs intrinsic-drive balance**
+(`audioWeight` vs `intrinsicExcitabilityDrive`) — watch it from the first runs.

--- a/rate/results/V3_PLAN.md
+++ b/rate/results/V3_PLAN.md
@@ -1,0 +1,44 @@
+# Version 3.0 direction (shelved — do not implement yet)
+
+Recorded so the design decision survives; **not** being built now. Current work
+continues with the ART secondary area.
+
+## Idea: replace ART with a trained one-hot classifier that has a "blank" class
+
+Motivation: ART's reject is a vigilance threshold and its complement-coded
+lower-envelope templates conflate brightness with content (the dimmed-horse
+reads-as-person confound, and the odd blind-phase match dynamics). A classifier
+with an explicit "nothing there" class turns the hallucination into a clean,
+plottable posterior — **P(person) rising while ground truth is blank** — and the
+"blank" prior makes the hallucination have to *overcome* a trained "no stimulus"
+representation rather than fall out of a threshold artifact (stronger, more
+honest test; still not tuned toward the result).
+
+## Decisions taken
+
+- **"Blank" class is trained on ZERO veridical (visual) input** — i.e. "no
+  stimulus present," NOT the deprived-cortex activity pattern. (Training blank on
+  the deprived state would teach the model to explain away the very thing we test.)
+- **Not frozen — slow to re-learn.** The classifier keeps a low learning rate so
+  it can acquire *new objects in the final epoch*, which is how the model would
+  show the **resolution of hallucinations** (the percept reorganizes as veridical
+  structure returns / cross-modal content stabilizes).
+- **Consequences of late online learning:**
+  - With no new labels available in the final epoch, that late learning likely
+    has to be **unsupervised** (self-organized categories), not supervised
+    one-hot. So "one-hot classifier" is the readout framing, but the learning
+    rule at the end is unsupervised.
+  - May require **two audio inputs** (rather than one) to give the cross-modal
+    stream enough structure to form/resolve distinct categories.
+
+## Open questions for when this is picked up
+
+- Exact unsupervised rule and how it reconciles with the one-hot readout (e.g. a
+  fixed labeled readout head over self-organizing feature clusters).
+- Top-down feedback gain: ART's vigilance was an implicit brake on the
+  classifier -> V1 -> classifier loop; a confident softmax with strong feedback
+  can latch. Set this gain deliberately.
+- What the two audio inputs represent and how they map onto V1.
+
+Keep the classifier modular (as now) so this can slot in without disturbing the
+V1 / Sulfaro-mixture / emergent-controller core.

--- a/rate/results/emergent_5ht/SUMMARY.md
+++ b/rate/results/emergent_5ht/SUMMARY.md
@@ -1,0 +1,61 @@
+# Emergent "Realistic 5HT" experiment (option B, ART off)
+
+Closed-loop, activity-driven version of the deafferentation response. The **only
+imposed event is the sensory loss**; a homeostatic controller reads the deprived
+region's activity deficit each update and ramps every deprivation response
+(intrinsic excitability, bottom-up gain, reduced V1 5HT, raised cross-modal 5HT,
+lowered plasticity threshold) in proportion to a single latent drive `h ∈ [0,1]`,
+which relaxes as remapping restores activity. Option B (`homeostaticGain=2.5`,
+`homeostaticTauRelax=6000`) makes the loop underdamped, so a transient
+hyperactivity overshoot emerges and then settles — none of it scheduled.
+
+Full 10×10 retinotopic grid, 8 cells/column, 2 classes (person/horse), real
+edge-detected image input. Epochs 5000 ms each (baseline + 3 observation
+windows); plasticity rate reduced 10× (`gamma_p/10`). ART classifier kept
+separate/off (rate trajectory is classifier-independent). Each mode is run with
+plasticity and with a no-plasticity control.
+
+## Results (deprived-region V1 firing rate, Hz)
+
+| mode    | set-point A_set | trough (at loss) | peak (overshoot) | final (plast) | final (control) | remap W: base→final |
+|---------|-----------------|------------------|------------------|---------------|-----------------|---------------------|
+| scotoma | 4.43            | 1.97             | 4.66             | 4.43          | 2.88            | 15 → 102            |
+| blind   | 3.53            | 1.82             | 4.64             | 4.63          | 2.58            | 15 → 103            |
+
+`h` peaks at 0.75 (scotoma) / 0.61 (blind) and relaxes to ~0.10 / ~0.07 by the
+end — i.e. the controller releases once activity is restored.
+
+## Reading the figures (per mode)
+
+- **homeostatic.png** — the headline: deprived rate (red) and latent drive `h`
+  (blue). Flat baseline → drop at loss → `h` emerges from zero → recovery →
+  transient overshoot → `h` relaxes / rate settles. Only the loss is imposed.
+- **rates.png** — plasticity vs no-plasticity control (and intact columns for the
+  scotoma). Control stays depressed; plasticity recovers.
+- **streams.png** — input streams into deprived V1: visual (lost at loss), audio
+  cross-modal (the remapping readout, climbs), top-down feedback.
+- **remap_weight.png** — mean audio→V1 remapping-synapse weight; potentiates
+  under plasticity, flat under control.
+- **v1_maps.png** — retinotopic V1 activity per epoch, lesion outlined; the
+  deprived region darkens at loss and re-lights after remapping.
+
+## Honest notes
+
+- **scotoma** overshoots then settles back onto its baseline set-point.
+- **blind** over-recovers and stabilizes *above* baseline (final 4.63 vs
+  set-point 3.53): under full blindness the cross-modal audio drive replaces and
+  exceeds the lost visual drive across the whole field, so once activity passes
+  set-point the controller releases (`h`→0) while the remapping weight it already
+  built persists and holds the rate high. This is a genuine model behavior, left
+  as-is (not tuned toward a target).
+- The baseline set-point differs between modes because it is the mean over the
+  *deprived cell set* — the whole field under blindness (3.53) vs only the lesion
+  patch under scotoma (4.43) — measured in epoch 1 before any loss is imposed.
+
+## vs. the scheduled "Realistic 5HT" version
+
+Same drop→hyperactivity→settle shape, but there the phase-3 responses are imposed
+as a fixed step (intrinsic drive 60, etc.), giving a larger, externally-clamped
+hyperactivity. Here the response magnitude is proportional to the *actual*
+measured deficit and self-limits via the loop, so the overshoot is gentler
+(~+5%) and the return is intrinsic rather than scheduled.

--- a/rate/results/emergent_5ht_art/SUMMARY.md
+++ b/rate/results/emergent_5ht_art/SUMMARY.md
@@ -1,0 +1,65 @@
+# Emergent "Realistic 5HT" experiment WITH ART secondary area (option B)
+
+Same emergent, closed-loop option-B run as `../emergent_5ht/`, but with the ART
+secondary area active: a Fuzzy ART classifier is pre-trained on the clean-V1
+representations of the labeled stimuli, then drives top-down feedback into V1 and
+is read out each step. Only the sensory loss is imposed; the homeostatic
+controller does the rest. Full 10×10 grid, 5000 ms epochs, `gamma_p/10`, real
+person/horse image input. Each mode paired with a no-plasticity control.
+
+Held stimulus true class = **horse** (label 0).
+
+## Rate trajectory (deprived-region V1, Hz)
+
+| mode    | A_set | trough | peak | final (plast) | final (control) | remap W: base→final |
+|---------|-------|--------|------|---------------|-----------------|---------------------|
+| scotoma | 3.98  | 1.49   | 4.24 | 4.04          | 2.57            | 15 → 100            |
+| blind   | 2.90  | 1.28   | 3.75 | 3.71          | 2.10            | 15 → 97             |
+
+Same emergent drop → overshoot → settle as ART-off; the classifier and its
+top-down feedback do not disrupt the rate homeostasis.
+
+## ART readout — the hallucination (art_readout.png)
+
+Both modes classify the stimulus correctly as **horse** at baseline. At the loss,
+both flip to a confident **"person"** decision — the wrong category — riding on
+the remapped cross-modal (audio) drive plus ART top-down feedback. This is the
+predicted cross-modal hallucination: a confident percept of a category that the
+veridical (now absent) input does not support.
+
+The two modes then diverge:
+
+- **scotoma (partial loss):** the "person" hallucination **latches and persists**
+  for the rest of the run, match confidence ~0.86, comfortably above vigilance
+  (0.75). The spared/intact surround and the sustained top-down feedback keep
+  reinforcing it.
+- **blind (full loss):** the hallucination is **transient**. With no intact
+  columns to anchor the percept, as the homeostatic drive `h` relaxes and the
+  top-down current collapses (return-epoch top-down ≈ 0.95, essentially off), the
+  ART match **erodes to the vigilance line (~12 s)** and the readout
+  **destabilizes into a person/reject oscillation, collapsing to reject**. Once
+  ART rejects, its top-down turns off, which keeps it rejecting — a
+  self-consistent feedback shutdown.
+
+## Honest notes
+
+- **No resolution to the correct class.** In neither mode does the readout return
+  to "horse". ART has no mechanism to *relearn* the true category while the
+  veridical input is gone, so the hallucination either persists (scotoma) or
+  decays into reject (blind) — it never corrects. Showing hallucination
+  *resolution* is precisely the goal of the shelved v3.0 classifier (see
+  `../V3_PLAN.md`): a slow, unsupervised late-relearning readout with a trained
+  "blank" class.
+- **The blind instability is vigilance-driven.** The person/reject oscillation
+  and collapse come from ART's match crossing the vigilance threshold — the same
+  threshold fragility noted earlier. A trained "blank" class (v3.0) would replace
+  this hard threshold with a learned decision boundary.
+- Top-down magnitude here (~30) reflects the ART path (`topDownDriveHz=30`),
+  distinct from the non-ART Category feedback in `../emergent_5ht/`.
+
+## Figures (per mode)
+
+- **art_readout.png** — ART decision strip (horse / person / reject) + match vs
+  vigilance. The headline hallucination trace.
+- **rates.png / streams.png / remap_weight.png / v1_maps.png / homeostatic.png**
+  — as in the ART-off run; the emergent rate story is unchanged.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 absl-py==0.9.0
 dill==0.3.1.1
+imageio==2.37.3
+imageio-ffmpeg==0.6.0
 matplotlib==3.2.1
 numpy==1.22.0
 scipy==1.4.1

--- a/sensory/BeepAudioSource.py
+++ b/sensory/BeepAudioSource.py
@@ -1,0 +1,47 @@
+import csv
+import math
+import numpy as np
+
+class BeepAudioSource:
+    """
+    Loads a simple beep score - a CSV of (time_ms, frequency_hz, amplitude) rows -
+    and maps it onto a 1D tonotopic array of firing rates, one band per column,
+    with log-spaced center frequencies and Gaussian frequency tuning per band.
+    """
+
+    def __init__(self, path, numBands=20, minFreqHz=200.0, maxFreqHz=5000.0,
+                 minRateHz=1.0, maxRateHz=40.0, tuningWidthOctaves=0.5):
+        self.path = path
+        self.numBands = numBands
+        self.minRateHz = minRateHz
+        self.maxRateHz = maxRateHz
+        self.tuningWidthOctaves = tuningWidthOctaves
+        self.bandCenterFreqsHz = np.logspace(math.log10(minFreqHz), math.log10(maxFreqHz), numBands)
+        self.bandCenterOctaves = np.log2(self.bandCenterFreqsHz)
+        self.events = self._loadEvents()
+
+    def _loadEvents(self):
+        events = []
+        with open(self.path, newline="") as beepFile:
+            reader = csv.DictReader(beepFile)
+            for row in reader:
+                events.append((float(row["time_ms"]), float(row["frequency_hz"]), float(row["amplitude"])))
+        events.sort(key=lambda event: event[0])
+        if len(events) == 0:
+            raise ValueError("Beep source %s contained no events" % self.path)
+        return events
+
+    def stateAtTime(self, timeMs):
+        # Step-hold: the most recent event at or before timeMs is in effect.
+        current = self.events[0]
+        for event in self.events:
+            if event[0] > timeMs:
+                break
+            current = event
+        return current[1], current[2]
+
+    def rateVectorAtTime(self, timeMs):
+        frequencyHz, amplitude = self.stateAtTime(timeMs)
+        freqOctaves = math.log2(max(frequencyHz, 1e-6))
+        tuning = np.exp(-((freqOctaves - self.bandCenterOctaves) ** 2) / (2 * self.tuningWidthOctaves ** 2))
+        return self.minRateHz + amplitude * tuning * (self.maxRateHz - self.minRateHz)

--- a/sensory/SyntheticFixtures.py
+++ b/sensory/SyntheticFixtures.py
@@ -1,0 +1,33 @@
+import csv
+import numpy as np
+import imageio.v3 as iio
+
+'''
+Small helpers for generating synthetic greyscale video / beep score fixtures,
+used by the automated tests so they don't depend on external media files.
+'''
+
+def writeSyntheticGreyscaleVideo(path, gridRows=10, gridCols=10, numFrames=8, fps=10):
+    # A bright square sweeps diagonally across an otherwise dim frame, giving
+    # every visual column some contrast to respond to over the clip.
+    frames = []
+    for t in range(numFrames):
+        frame = np.full((gridRows, gridCols), 40, dtype=np.uint8)
+        center = int(t * (min(gridRows, gridCols) - 1) / max(numFrames - 1, 1))
+        rowStart, rowEnd = max(0, center - 1), min(gridRows, center + 2)
+        colStart, colEnd = max(0, center - 1), min(gridCols, center + 2)
+        frame[rowStart:rowEnd, colStart:colEnd] = 220
+        frames.append(frame)
+    iio.imwrite(path, frames, fps=fps, macro_block_size=1)
+    return path
+
+def writeSyntheticBeepScore(path, events=None):
+    # events: list of (time_ms, frequency_hz, amplitude) tuples
+    if events is None:
+        events = [(0, 440.0, 1.0), (25, 1800.0, 1.0), (50, 3200.0, 0.8)]
+    with open(path, "w", newline="") as beepFile:
+        writer = csv.writer(beepFile)
+        writer.writerow(["time_ms", "frequency_hz", "amplitude"])
+        for event in events:
+            writer.writerow(event)
+    return path

--- a/sensory/VideoFrameSource.py
+++ b/sensory/VideoFrameSource.py
@@ -1,0 +1,60 @@
+import numpy as np
+import imageio.v3 as iio
+
+class VideoFrameSource:
+    """
+    Decodes a greyscale video file into a sequence of retinotopic firing-rate
+    frames, one per video frame, each downsampled to a (gridRows x gridCols) grid.
+    """
+
+    def __init__(self, path, gridRows=10, gridCols=10, minRateHz=1.0, maxRateHz=40.0):
+        self.path = path
+        self.gridRows = gridRows
+        self.gridCols = gridCols
+        self.minRateHz = minRateHz
+        self.maxRateHz = maxRateHz
+        self.rateFrames = self._loadRateFrames()
+
+    def _loadRateFrames(self):
+        rateFrames = []
+        for frame in iio.imiter(self.path):
+            grey = self._toGreyscale(frame)
+            downsampled = self._downsample(grey)
+            rateFrames.append(self._toRate(downsampled))
+        if len(rateFrames) == 0:
+            raise ValueError("Video source %s contained no frames" % self.path)
+        return rateFrames
+
+    @staticmethod
+    def _toGreyscale(frame):
+        frame = np.asarray(frame, dtype=float)
+        if frame.ndim == 3:
+            frame = frame[..., :3].mean(axis=-1)
+        return frame
+
+    def _downsample(self, frame):
+        # Average-pool the source frame down to (gridRows x gridCols), using bin
+        # edges so this works for any source resolution, not just exact multiples.
+        rowEdges = np.linspace(0, frame.shape[0], self.gridRows + 1).astype(int)
+        colEdges = np.linspace(0, frame.shape[1], self.gridCols + 1).astype(int)
+        out = np.zeros((self.gridRows, self.gridCols))
+        for r in range(self.gridRows):
+            rowStart, rowEnd = rowEdges[r], max(rowEdges[r + 1], rowEdges[r] + 1)
+            for c in range(self.gridCols):
+                colStart, colEnd = colEdges[c], max(colEdges[c + 1], colEdges[c] + 1)
+                out[r, c] = frame[rowStart:rowEnd, colStart:colEnd].mean()
+        return out
+
+    def _toRate(self, greyGrid):
+        normalized = greyGrid / 255.0
+        return self.minRateHz + normalized * (self.maxRateHz - self.minRateHz)
+
+    def frameCount(self):
+        return len(self.rateFrames)
+
+    def rateFrameAt(self, frameIndex):
+        return self.rateFrames[frameIndex % len(self.rateFrames)]
+
+    def rateFrameAtTime(self, timeMs, frameDurationMs):
+        frameIndex = int(timeMs // frameDurationMs)
+        return self.rateFrameAt(frameIndex)

--- a/simulation/RetinotopicAVSimulation.py
+++ b/simulation/RetinotopicAVSimulation.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy import arange
 from network.RetinotopicAVNetwork import RetinotopicAVNetwork
 
@@ -58,6 +59,16 @@ class RetinotopicAVSimulation():
         self.remappingAxons = self._collectRemappingAxons()
         self.weightsPrior = None
         self.weightsPost = None
+
+        # weightHistory: (time, mean remapping-synapse weight) sampled every
+        # step across the whole run, for plotting how remapping unfolds over
+        # time rather than just the phase3 before/after snapshot.
+        self.weightHistory = []
+        # activitySnapshots: phase name -> (gridRows x gridCols) array of each
+        # visual column's most recent firing rate, for spatial "where is the
+        # activity" figures (e.g. showing the scotoma and its later refill).
+        self.activitySnapshots = {}
+        self._lastPhaseWindow = None
 
         self._lastFrameIndex = None
         self._lastAudioState = None
@@ -126,12 +137,39 @@ class RetinotopicAVSimulation():
         for t in tspan:
             self._driveInputs(t, muteVisual)
             self.network.step()
+            if self.remappingAxons:
+                meanWeight = float(np.mean([axon.postSynapticReceptors[0].weight for axon in self.remappingAxons]))
+                self.weightHistory.append((t, meanWeight))
+        self._lastPhaseWindow = (start, end)
+
+    def visualActivitySnapshot(self, windowStart, windowEnd):
+        # Mean per-cell firing rate strictly within [windowStart, windowEnd),
+        # arranged spatially - this is what shows a scotoma "going dark" and
+        # later refilling. This has to be scoped to the phase's own window
+        # (rather than reusing Population.rateRecord's fixed trailing-50ms
+        # window) because phases here are shorter than 50ms, so a trailing
+        # window would blur into the previous phase.
+        windowSize = windowEnd - windowStart
+        grid = np.zeros((self.network.gridRows, self.network.gridCols))
+        for (r, c), colName in self.network.visualColumnNames.items():
+            population = self.network.populations["pyramidals" + colName]
+            spikeCount = 0
+            for cell in population.cells:
+                for spike in reversed(cell.spikeRecord):
+                    if spike <= windowStart:
+                        break
+                    if spike < windowEnd:
+                        spikeCount += 1
+            grid[r, c] = (spikeCount / len(population.cells)) * (1000.0 / windowSize)
+        return grid
 
     def phase1(self):
         self.runPhase(1, muteVisual=False)
+        self.activitySnapshots["1_full_input"] = self.visualActivitySnapshot(*self._lastPhaseWindow)
 
     def phase2(self):
         self.runPhase(2, muteVisual=True)
+        self.activitySnapshots["2_sensory_loss"] = self.visualActivitySnapshot(*self._lastPhaseWindow)
 
     def phase3(self):
         # NOTE: axon.weight is a static snapshot fixed at construction time.
@@ -150,6 +188,7 @@ class RetinotopicAVSimulation():
         self.runPhase(3, muteVisual=True)
 
         self.weightsPost = [axon.postSynapticReceptors[0].weight for axon in self.remappingAxons]
+        self.activitySnapshots["3_serotonin_plasticity"] = self.visualActivitySnapshot(*self._lastPhaseWindow)
 
     def phase4(self):
         for axon in self.remappingAxons:
@@ -159,6 +198,7 @@ class RetinotopicAVSimulation():
         self.network.setSerotoninForColumns(self._affectedColumnNames(), baselineTransmitters)
 
         self.runPhase(4, muteVisual=True)
+        self.activitySnapshots["4_remapped"] = self.visualActivitySnapshot(*self._lastPhaseWindow)
 
     def run(self):
         self.phase1()

--- a/simulation/RetinotopicAVSimulation.py
+++ b/simulation/RetinotopicAVSimulation.py
@@ -25,10 +25,23 @@ Two lesion modes are supported:
               neighbors, so remapping is instead carried by the cross-modal
               audio -> visual connections at the two grid edges, mirroring
               cross-modal reorganization following complete visual loss.
+
+Visual input is presented as discrete flashes (params["flashDurationMs"] of
+real video-driven rates) separated by blank inter-stimulus intervals
+(params["blankDurationMs"] at baselineRateV), repeating for as long as visual
+input isn't muted. Earlier versions drove the visual columns continuously
+from a small looping video clip for the whole run, which gave every column a
+sustained, unchanging drive with no onset transients or rest between them -
+on inspection that made it impossible to tell a real stimulus response apart
+from this network's baseline tendency to drift upward under any sustained
+input. Flash/blank cycling doesn't fix that tendency by itself, but it at
+least gives the visual columns recurring transitions to respond to, instead
+of one uninterrupted ramp. Audio is unaffected and keeps driving continuously
+throughout, per the "audio stays active" requirement.
 '''
 
 class RetinotopicAVSimulation():
-    def __init__(self, params, videoSource, audioSource, lesionMode="scotoma"):
+    def __init__(self, params, videoSource, audioSource, lesionMode="scotoma", enableRemapping=True):
         if lesionMode not in ("scotoma", "full"):
             raise ValueError("lesionMode must be 'scotoma' or 'full', got %r" % lesionMode)
         self.params = params
@@ -36,7 +49,15 @@ class RetinotopicAVSimulation():
         self.videoSource = videoSource
         self.audioSource = audioSource
         self.lesionMode = lesionMode
+        # enableRemapping=False is a control condition: phase3/phase4 still
+        # run (same duration, same muting), but serotonin never rises and
+        # plasticity never switches on. Comparing against this control is the
+        # only way to tell genuine remapping (caused by the potentiated
+        # synapses) apart from generic network drift over time.
+        self.enableRemapping = enableRemapping
         self.frameDurationMs = params["frameDurationMs"]
+        self.flashDurationMs = params.get("flashDurationMs", self.frameDurationMs)
+        self.blankDurationMs = params.get("blankDurationMs", self.frameDurationMs)
         self.network = RetinotopicAVNetwork(self.tau, self, params, "RetinotopicAVNetwork_" + lesionMode)
 
         gridRows = self.network.gridRows
@@ -70,7 +91,7 @@ class RetinotopicAVSimulation():
         self.activitySnapshots = {}
         self._lastPhaseWindow = None
 
-        self._lastFrameIndex = None
+        self._lastDrivenState = None
         self._lastAudioState = None
 
     def _collectRemappingAxons(self):
@@ -103,15 +124,29 @@ class RetinotopicAVSimulation():
             coords = coords + self.spareNeighborColumns
         return [self.network.visualColumnNames[rc] for rc in coords]
 
+    def _isFlashOn(self, t):
+        cycle = self.flashDurationMs + self.blankDurationMs
+        if cycle <= 0:
+            return True
+        return (t % cycle) < self.flashDurationMs
+
+    def _blankVisualGrid(self):
+        return np.full((self.network.gridRows, self.network.gridCols), self.params["baselineRateV"])
+
     def _driveInputs(self, t, muteVisual):
         # Only push new rates into the input populations when the underlying
-        # video frame / beep state actually changes, instead of on every tau
-        # step - the network step itself dominates runtime, so this avoids
-        # thousands of redundant setRate() calls across a phase.
+        # video frame / flash-vs-blank state actually changes, instead of on
+        # every tau step - the network step itself dominates runtime, so this
+        # avoids thousands of redundant setRate() calls across a phase.
+        flashOn = self._isFlashOn(t)
         frameIndex = int(t // self.frameDurationMs)
-        if frameIndex != self._lastFrameIndex:
-            self._lastFrameIndex = frameIndex
-            self.network.setVisualInputRates(self.videoSource.rateFrameAt(frameIndex))
+        drivenState = (frameIndex, flashOn)
+        if drivenState != self._lastDrivenState:
+            self._lastDrivenState = drivenState
+            if flashOn:
+                self.network.setVisualInputRates(self.videoSource.rateFrameAt(frameIndex))
+            else:
+                self.network.setVisualInputRates(self._blankVisualGrid())
             if muteVisual:
                 self._muteLesionedColumns()
 
@@ -130,9 +165,9 @@ class RetinotopicAVSimulation():
         end = maxTime * phase
         tspan = arange(start, end, self.tau)
         # Force the first step of every phase to re-apply rates (and muting,
-        # if this phase requires it), since the frame/beep index alone can't
-        # tell a phase transition apart from an unchanged frame.
-        self._lastFrameIndex = None
+        # if this phase requires it), since the frame/flash/beep state alone
+        # can't tell a phase transition apart from an unchanged state.
+        self._lastDrivenState = None
         self._lastAudioState = None
         for t in tspan:
             self._driveInputs(t, muteVisual)
@@ -178,12 +213,13 @@ class RetinotopicAVSimulation():
         # exactly as TwoColumnSimulation reads source.postSynapticReceptors[0].weight.
         self.weightsPrior = [axon.postSynapticReceptors[0].weight for axon in self.remappingAxons]
 
-        raisedTransmitters = {"5HT2A": self.params["remapSerotoninLevel"], "5HT1A": self.params["remapSerotoninLevel"]}
-        self.network.setSerotoninForColumns(self._affectedColumnNames(), raisedTransmitters)
+        if self.enableRemapping:
+            raisedTransmitters = {"5HT2A": self.params["remapSerotoninLevel"], "5HT1A": self.params["remapSerotoninLevel"]}
+            self.network.setSerotoninForColumns(self._affectedColumnNames(), raisedTransmitters)
 
-        for axon in self.remappingAxons:
-            axon.postSynapticReceptors[0].plasticity = True
-            axon.postSynapticReceptors[0].c_p = self.params["remapPlasticityCp"]
+            for axon in self.remappingAxons:
+                axon.postSynapticReceptors[0].plasticity = True
+                axon.postSynapticReceptors[0].c_p = self.params["remapPlasticityCp"]
 
         self.runPhase(3, muteVisual=True)
 
@@ -191,11 +227,12 @@ class RetinotopicAVSimulation():
         self.activitySnapshots["3_serotonin_plasticity"] = self.visualActivitySnapshot(*self._lastPhaseWindow)
 
     def phase4(self):
-        for axon in self.remappingAxons:
-            axon.postSynapticReceptors[0].plasticity = False
+        if self.enableRemapping:
+            for axon in self.remappingAxons:
+                axon.postSynapticReceptors[0].plasticity = False
 
-        baselineTransmitters = {"5HT2A": self.params["serotoninLevelV"], "5HT1A": self.params["serotoninLevelV"]}
-        self.network.setSerotoninForColumns(self._affectedColumnNames(), baselineTransmitters)
+            baselineTransmitters = {"5HT2A": self.params["serotoninLevelV"], "5HT1A": self.params["serotoninLevelV"]}
+            self.network.setSerotoninForColumns(self._affectedColumnNames(), baselineTransmitters)
 
         self.runPhase(4, muteVisual=True)
         self.activitySnapshots["4_remapped"] = self.visualActivitySnapshot(*self._lastPhaseWindow)

--- a/simulation/RetinotopicAVSimulation.py
+++ b/simulation/RetinotopicAVSimulation.py
@@ -1,0 +1,167 @@
+from numpy import arange
+from network.RetinotopicAVNetwork import RetinotopicAVNetwork
+
+'''
+Phase-based simulation for RetinotopicAVNetwork, following the same
+progression as TwoColumnSimulation's phase1..phase4:
+
+  phase1: full input (video + audio both driving normally)
+  phase2: loss of visual input - the lesioned columns are muted. Audio keeps
+          driving normally throughout every phase.
+  phase3: serotonin rises in the affected region and plasticity is switched
+          on for the "remapping" connections that carry spared input into the
+          deprived columns, allowing them to potentiate.
+  phase4: plasticity switches back off and serotonin returns to baseline -
+          the deprived columns are now driven by the remapped pathway, and
+          that stays stable for further running.
+
+Two lesion modes are supported:
+  "scotoma" - a contiguous block of visual columns is silenced. Remapping is
+              carried by lateral pyramidal -> pyramidal connections from the
+              spared grid-neighbor columns into the lesioned block, mirroring
+              classic cortical remapping around a focal visual field lesion.
+  "full"    - every visual column is silenced. There are no spared visual
+              neighbors, so remapping is instead carried by the cross-modal
+              audio -> visual connections at the two grid edges, mirroring
+              cross-modal reorganization following complete visual loss.
+'''
+
+class RetinotopicAVSimulation():
+    def __init__(self, params, videoSource, audioSource, lesionMode="scotoma"):
+        if lesionMode not in ("scotoma", "full"):
+            raise ValueError("lesionMode must be 'scotoma' or 'full', got %r" % lesionMode)
+        self.params = params
+        self.tau = params["tau"]
+        self.videoSource = videoSource
+        self.audioSource = audioSource
+        self.lesionMode = lesionMode
+        self.frameDurationMs = params["frameDurationMs"]
+        self.network = RetinotopicAVNetwork(self.tau, self, params, "RetinotopicAVNetwork_" + lesionMode)
+
+        gridRows = self.network.gridRows
+        gridCols = self.network.gridCols
+        if lesionMode == "full":
+            self.lesionedColumns = [(r, c) for r in range(gridRows) for c in range(gridCols)]
+        else:
+            scotomaRows = params.get("scotomaRows", range(gridRows // 2 - 1, gridRows // 2 + 1))
+            scotomaCols = params.get("scotomaCols", range(gridCols // 2 - 1, gridCols // 2 + 1))
+            self.lesionedColumns = [(r, c) for r in scotomaRows for c in scotomaCols]
+        self.lesionedSet = set(self.lesionedColumns)
+
+        self.spareNeighborColumns = sorted({
+            neighbor
+            for (r, c) in self.lesionedColumns
+            for neighbor in self.network.gridNeighbors(r, c)
+            if neighbor not in self.lesionedSet
+        })
+
+        self.remappingAxons = self._collectRemappingAxons()
+        self.weightsPrior = None
+        self.weightsPost = None
+
+        self._lastFrameIndex = None
+        self._lastAudioState = None
+
+    def _collectRemappingAxons(self):
+        # The specific connections that carry spared activity into the deprived
+        # columns - these are the ones whose weights should grow during phase3
+        # if remapping is actually happening.
+        axons = []
+        if self.lesionMode == "scotoma":
+            for (nr, nc) in self.spareNeighborColumns:
+                neighborName = self.network.visualColumnNames[(nr, nc)]
+                for (lr, lc) in self.network.gridNeighbors(nr, nc):
+                    if (lr, lc) in self.lesionedSet:
+                        lesionedName = self.network.visualColumnNames[(lr, lc)]
+                        axons.extend(self.network.getAxonsBetween("pyramidals" + neighborName, "pyramidals" + lesionedName))
+        else:
+            for r in range(self.network.gridRows):
+                for c in (0, self.network.gridCols - 1):
+                    visualName = self.network.visualColumnNames[(r, c)]
+                    audioIndex = self.network.leftEdgeBandForRow[r] if c == 0 else self.network.rightEdgeBandForRow[r]
+                    audioName = self.network.audioColumnNames[int(audioIndex)]
+                    axons.extend(self.network.getAxonsBetween("Input" + audioName, "pyramidals" + visualName))
+        return axons
+
+    def _affectedColumnNames(self):
+        # Columns whose serotonin level rises during phase3: the lesioned
+        # columns themselves, plus (for the scotoma case) the spared
+        # neighbors that are being asked to take over.
+        coords = list(self.lesionedColumns)
+        if self.lesionMode == "scotoma":
+            coords = coords + self.spareNeighborColumns
+        return [self.network.visualColumnNames[rc] for rc in coords]
+
+    def _driveInputs(self, t, muteVisual):
+        # Only push new rates into the input populations when the underlying
+        # video frame / beep state actually changes, instead of on every tau
+        # step - the network step itself dominates runtime, so this avoids
+        # thousands of redundant setRate() calls across a phase.
+        frameIndex = int(t // self.frameDurationMs)
+        if frameIndex != self._lastFrameIndex:
+            self._lastFrameIndex = frameIndex
+            self.network.setVisualInputRates(self.videoSource.rateFrameAt(frameIndex))
+            if muteVisual:
+                self._muteLesionedColumns()
+
+        audioState = self.audioSource.stateAtTime(t)
+        if audioState != self._lastAudioState:
+            self._lastAudioState = audioState
+            self.network.setAudioInputRates(self.audioSource.rateVectorAtTime(t))
+
+    def _muteLesionedColumns(self):
+        for (r, c) in self.lesionedColumns:
+            self.network.setVisualInputRate(r, c, 0)
+
+    def runPhase(self, phase, muteVisual):
+        maxTime = self.params["phaseDurationMs"]
+        start = maxTime * (phase - 1)
+        end = maxTime * phase
+        tspan = arange(start, end, self.tau)
+        # Force the first step of every phase to re-apply rates (and muting,
+        # if this phase requires it), since the frame/beep index alone can't
+        # tell a phase transition apart from an unchanged frame.
+        self._lastFrameIndex = None
+        self._lastAudioState = None
+        for t in tspan:
+            self._driveInputs(t, muteVisual)
+            self.network.step()
+
+    def phase1(self):
+        self.runPhase(1, muteVisual=False)
+
+    def phase2(self):
+        self.runPhase(2, muteVisual=True)
+
+    def phase3(self):
+        # NOTE: axon.weight is a static snapshot fixed at construction time.
+        # The live, plasticity-updated weight lives on the postsynaptic
+        # receptor (see GlutGSDReceptor.boutonSpike / postSynapticSpikeFeedback),
+        # exactly as TwoColumnSimulation reads source.postSynapticReceptors[0].weight.
+        self.weightsPrior = [axon.postSynapticReceptors[0].weight for axon in self.remappingAxons]
+
+        raisedTransmitters = {"5HT2A": self.params["remapSerotoninLevel"], "5HT1A": self.params["remapSerotoninLevel"]}
+        self.network.setSerotoninForColumns(self._affectedColumnNames(), raisedTransmitters)
+
+        for axon in self.remappingAxons:
+            axon.postSynapticReceptors[0].plasticity = True
+            axon.postSynapticReceptors[0].c_p = self.params["remapPlasticityCp"]
+
+        self.runPhase(3, muteVisual=True)
+
+        self.weightsPost = [axon.postSynapticReceptors[0].weight for axon in self.remappingAxons]
+
+    def phase4(self):
+        for axon in self.remappingAxons:
+            axon.postSynapticReceptors[0].plasticity = False
+
+        baselineTransmitters = {"5HT2A": self.params["serotoninLevelV"], "5HT1A": self.params["serotoninLevelV"]}
+        self.network.setSerotoninForColumns(self._affectedColumnNames(), baselineTransmitters)
+
+        self.runPhase(4, muteVisual=True)
+
+    def run(self):
+        self.phase1()
+        self.phase2()
+        self.phase3()
+        self.phase4()


### PR DESCRIPTION
## Summary
This PR introduces a retinotopic visual network and tonotopic audio network with cross-modal connectivity, enabling simulation of cortical remapping following sensory loss. The implementation extends the existing serotonin-modulated plasticity framework to a spatially-organized grid architecture.

## Key Changes

**New Network Architecture:**
- `RetinotopicAVNetwork`: A grid-based network with 10×10 visual columns (one per pixel of downsampled video) and 20 tonotopic audio columns (one per frequency band)
- Each column maintains the same internal structure as the original SerotoninAVNetwork (Input → Pyramidal → FS/LTS populations with E/I dynamics)
- Lateral connectivity is topographic: visual columns connect to 4-connected grid neighbors; audio columns form a 1D tonotopic chain
- Cross-modal connections link visual field edges to audio frequency bands (left edge → low frequencies, right edge → high frequencies)

**Simulation Framework:**
- `RetinotopicAVSimulation`: Four-phase simulation protocol mirroring sensory loss and recovery
  - Phase 1: Full input (video + audio)
  - Phase 2: Visual input loss (scotoma or full-field)
  - Phase 3: Serotonin elevation + plasticity enabling remapping through spared pathways
  - Phase 4: Return to baseline with stable remapped state
- Supports two lesion modes: "scotoma" (focal visual field loss with lateral remapping) and "full" (complete visual loss with cross-modal remapping)

**Sensory Input Sources:**
- `VideoFrameSource`: Decodes greyscale video into retinotopic firing-rate grids with configurable downsampling
- `BeepAudioSource`: Maps beep score events onto tonotopic frequency bands with Gaussian tuning curves
- `SyntheticFixtures`: Generates synthetic video and beep score for testing

**Testing:**
- `TestRetinotopicAVNetwork`: Comprehensive test verifying network topology, remapping axon identification, and synaptic potentiation in both lesion scenarios

## Implementation Details

- Weight scaling adjusted for smaller population counts (8 vs. 40 neurons) to maintain physiologically plausible firing rates
- Remapping axons are explicitly tracked during construction for weight monitoring across phases
- Input rate updates are cached to avoid redundant calls during video frame/beep state transitions
- Spike history lookup optimized in `Population.getSpikeRatePerSecond()` to scan backward from recent spikes rather than rescanning entire history
- `PoissonNeuron` and `PoissonPopulation` extended with `setRate()` methods for dynamic input control

https://claude.ai/code/session_01UumepoKk4C3aXovpBfp21J